### PR TITLE
Use MADV_REMOVE on Linux, MADV_DONTNEED otherwise

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lgalloc"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 authors = ["Moritz Hoffmann <antiguru@gmail.com>"]
 description = "Large object allocator"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,6 +38,12 @@ const INITIAL_SIZE: usize = 32 << 20;
 /// Range of valid size classes.
 pub const VALID_SIZE_CLASS: Range<usize> = 16..33;
 
+#[cfg(target_os = "linux")]
+pub const MADV_DONTNEED_STRATEGY: libc::c_int = libc::MADV_REMOVE;
+
+#[cfg(not(target_os = "linux"))]
+pub const MADV_DONTNEED_STRATEGY: libc::c_int = libc::MADV_DONTNEED;
+
 type PhantomUnsync = PhantomData<Cell<()>>;
 type PhantomUnsend = PhantomData<MutexGuard<'static, ()>>;
 


### PR DESCRIPTION
Currently, MADV_REMOVE is only supported on Linux, so use the more portable MADV_DONTNEED on other targets.