### PR TITLE
Fix MADV_DONTNEED_STRATEGY

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lgalloc"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 authors = ["Moritz Hoffmann <antiguru@gmail.com>"]
 description = "Large object allocator"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -509,7 +509,8 @@ impl BackgroundWorker {
 
     fn clear_area(mem: &mut Mem) -> std::io::Result<()> {
         // SAFETY: Calling into `madvise`
-        let ret = unsafe { libc::madvise(mem.as_mut_ptr().cast(), mem.len(), libc::MADV_REMOVE) };
+        let ret =
+            unsafe { libc::madvise(mem.as_mut_ptr().cast(), mem.len(), MADV_DONTNEED_STRATEGY) };
         if ret != 0 {
             let err = std::io::Error::last_os_error();
             eprintln!("madvise failed: {ret} {err:?}",);


### PR DESCRIPTION
We didn't actually use the value before, breaking builds on Mac.