### PR TITLE
Relax version requirements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lgalloc"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 authors = ["Moritz Hoffmann <antiguru@gmail.com>"]
 description = "Large object allocator"
@@ -9,10 +9,10 @@ repository = "https://github.com/antiguru/rust-lgalloc"
 rust-version = "1.70"
 
 [dependencies]
-crossbeam-deque = "0.8"
+crossbeam-deque = "0.8.3"
 libc = "0.2"
-memmap2 = "0.9"
-tempfile = "3.8"
+memmap2 = "0.5"
+tempfile = "3"
 thiserror = "1.0"
 
 [profile.bench]


### PR DESCRIPTION
This makes it easier for other projects to consume lgalloc.