### PR TITLE
review unsafe code

### DIFF
--- a/examples/leak.rs
+++ b/examples/leak.rs
@@ -1,0 +1,14 @@
+use lgalloc::Region;
+
+fn main() {
+    lgalloc::lgalloc_set_config(&lgalloc::LgAlloc {
+        enabled: Some(true),
+        path: Some(std::env::temp_dir()),
+        background_config: None,
+    });
+    let r = Region::<i32>::new_mmap(10000).unwrap();
+
+    let thread = std::thread::spawn(move || drop(r));
+
+    thread.join().unwrap();
+}

--- a/examples/repro.rs
+++ b/examples/repro.rs
@@ -1,0 +1,14 @@
+use lgalloc::Region;
+
+fn main() {
+    lgalloc::lgalloc_set_config(&lgalloc::LgAlloc {
+        enabled: Some(true),
+        path: Some(std::env::temp_dir()),
+        background_config: None,
+    });
+    if let Region::MMap(ref mut v, _) = Region::<i32>::new_mmap(10000).unwrap() {
+        let mut mine = Vec::<i32>::new();
+        std::mem::swap(v, &mut mine);
+        drop(mine);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,7 +63,7 @@ pub enum AllocError {
     OutOfMemory,
     /// Size class too large or small
     #[error("Invalid size class")]
-    InvalidSizeClass,
+    InvalidSizeClass(usize),
     /// Allocator disabled
     #[error("Disabled by configuration")]
     Disabled,
@@ -118,7 +118,7 @@ impl TryFrom<usize> for SizeClass {
         if VALID_SIZE_CLASS.contains(&value) {
             Ok(SizeClass(value))
         } else {
-            Err(AllocError::InvalidSizeClass)
+            Err(AllocError::InvalidSizeClass(value))
         }
     }
 }


### PR DESCRIPTION
I haven't deeply reviewing the usage of this code, but I did look at LgAllocRegion and its `Region` impl in https://github.com/MaterializeInc/materialize/pull/22723 to ensure I understood the intended purpose

I think there is at least some unexploited UB in this impl as it stands, but I believe it to all be fixable, at the cost of some inconvenience (dealing with pointers more). This unfortunately is the cost of `unsafe` in rust, which is widely considered _much_ harder to write with no hidden ub than even c :( 

This is just a first pass, I need to think and read more about the rust ub rules, especially the aliasing rules; its possible we don't need to worry about aliasing at all if we back everything with `*mut T`, though i am not 100% sure. 

Adding a rust cfg that change the `MMapMut`'s to `Vec`'s and allowing us to run Miri would be a great way to check our work!