### PR TITLE
Use the actual page size to determine the minimum allocation size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ rust-version = "1.70"
 crossbeam-deque = "0.8.3"
 libc = "0.2"
 memmap2 = "0.5"
+page_size = "0.6.0"
 tempfile = "3"
 thiserror = "1.0"
 


### PR DESCRIPTION
Change the minimum allocation size from fixed 4k to the system's page size. This is arguably more correct and should have been the approach from the beginning.