### PR TITLE
Add API to disable lgalloc globally

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,8 @@
 name: "Test Suite"
 on:
   push:
+    branches:
+      - "main"
   pull_request:
 
 jobs:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -795,6 +795,12 @@ impl LgAlloc {
         self
     }
 
+    /// Disable lgalloc globally.
+    pub fn disable(&mut self) -> &mut Self {
+        self.enabled = Some(false);
+        self
+    }
+
     /// Set the background worker configuration.
     pub fn with_background_config(&mut self, config: BackgroundWorkerConfig) -> &mut Self {
         self.background_config = Some(config);
@@ -1224,5 +1230,12 @@ mod test {
         assert!(!stats.size_class.is_empty());
 
         Ok(())
+    }
+
+    #[test]
+    #[serial]
+    fn test_disable() {
+        crate::lgalloc_set_config(&*LgAlloc::new().disable());
+        assert!(matches!(allocate::<u8>(1024), Err(AllocError::Disabled)));
     }
 }


### PR DESCRIPTION
This fixes as API oversight: It's possible to enable lgalloc, but not to disable it later. This fixes the problem by introducing a `disable` function on the configuration object.