### PR TITLE
File growth dampener

### DIFF
--- a/examples/disk_usage.rs
+++ b/examples/disk_usage.rs
@@ -8,6 +8,7 @@ fn main() {
     config.enable();
     config.eager_return(true);
     config.with_path(std::env::temp_dir());
+    config.file_growth_dampener(2);
     lgalloc::lgalloc_set_config(&config);
 
     println!("Allocating {buffers} regions of {buffer_size} size...");

--- a/examples/disk_usage.rs
+++ b/examples/disk_usage.rs
@@ -8,7 +8,6 @@ fn main() {
     config.enable();
     config.eager_return(true);
     config.with_path(std::env::temp_dir());
-    config.file_growth_dampener(2);
     lgalloc::lgalloc_set_config(&config);
 
     println!("Allocating {buffers} regions of {buffer_size} size...");


### PR DESCRIPTION
Introduce a file growth dampener to grow files by a factor of `1+1/(d+1)` instead of doubling. Supplying a growth dampener of 0 reverts to the current behavior.

Fixes #56.