### PR TITLE
Assign thread name to background worker

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -761,7 +761,10 @@ pub fn lgalloc_set_config(config: &LgAlloc) {
         if let Some(config) = config {
             let (sender, receiver) = std::sync::mpsc::channel();
             let mut worker = BackgroundWorker::new(receiver);
-            let join_handle = std::thread::spawn(move || worker.run());
+            let join_handle = std::thread::Builder::new()
+                .name("lgalloc-0".to_string())
+                .spawn(move || worker.run())
+                .expect("thread started successfully");
             sender.send(config).expect("Receiver exists");
             *lock = Some((join_handle, sender));
         }


### PR DESCRIPTION
Without assigning a thread name, we'd inherit the caller's thread name,
which can be confusing in profiles. Fix the thread name to "lgalloc-0".

Fixes #55.

Signed-off-by: Moritz Hoffmann <antiguru@gmail.com>
