### PR TITLE
Split fast and slow stats

### DIFF
--- a/examples/disk_usage.rs
+++ b/examples/disk_usage.rs
@@ -45,13 +45,13 @@ fn main() {
 fn print_stats() {
     let stats = lgalloc::lgalloc_stats_with_mapping().unwrap();
 
-    for (size_class, file_stats) in &stats.file_stats {
+    for (size_class, file_stats) in &stats.file {
         match file_stats {
             Ok(file_stats) => println!("file_stats {size_class} {file_stats:?}"),
             Err(e) => eprintln!("Failed to read file stats for size class {size_class}: {e}"),
         }
     }
-    for (size_class, map_stats) in stats.map_stats.iter().flatten() {
+    for (size_class, map_stats) in stats.map.iter().flatten() {
         println!("map_stats {size_class} {map_stats:?}");
     }
 }

--- a/examples/disk_usage.rs
+++ b/examples/disk_usage.rs
@@ -43,14 +43,15 @@ fn main() {
 }
 
 fn print_stats() {
-    let stats = lgalloc::lgalloc_stats();
+    let stats = lgalloc::lgalloc_stats_with_mapping().unwrap();
 
-    match &stats.file_stats {
-        Ok(file_stats) => {
-            for file_stat in file_stats {
-                println!("{file_stat:?}");
-            }
+    for (size_class, file_stats) in &stats.file_stats {
+        match file_stats {
+            Ok(file_stats) => println!("file_stats {size_class} {file_stats:?}"),
+            Err(e) => eprintln!("Failed to read file stats for size class {size_class}: {e}"),
         }
-        Err(err) => eprintln!("Failed to get file stats: {err}"),
+    }
+    for (size_class, map_stats) in stats.map_stats.iter().flatten() {
+        println!("map_stats {size_class} {map_stats:?}");
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -974,7 +974,7 @@ impl LgAllocStats {
         Self {
             size_class: size_class_stats,
             file: file_stats,
-            map: numa_map.is_some().then_some(map_stats),
+            map: numa_map.map(|_| map_stats),
         }
     }
 }


### PR DESCRIPTION
Split stats collection into a fast and slow variant. Reading the `numa_maps` file can take multiple seconds, and cause contention with operations modifying the virtual address space, so do not call it by default.
