### PR TITLE
Replace file-backed mappings with anonymous + THP

### DIFF
--- a/BENCH.md
+++ b/BENCH.md
@@ -1,0 +1,72 @@
+# Running lgalloc benchmarks on a target host
+
+## Prerequisites
+
+* Rust toolchain (stable)
+* `systemd-run` (systemd 232+, any modern Linux)
+* Swap enabled (for paging benchmarks)
+
+## Build
+
+```sh
+cargo build --release --bench alloc_bench
+```
+
+The binary is at `target/release/deps/alloc_bench-*` (pick the newest non-`.d` file).
+
+## Throughput benchmarks
+
+Measures lgalloc, system allocator, and raw mmap across 1/2/4/8/16 threads.
+Limits: 4G RAM, no swap, 16 CPUs.
+
+```sh
+BENCH=$(ls -t target/release/deps/alloc_bench-* | grep -v '\.d$' | head -1)
+systemd-run --user -p MemoryMax=4G -p MemorySwapMax=0 -p CPUQuota=1600% \
+  --wait --pipe "$BENCH"
+```
+
+Adjust `CPUQuota` to match the host (100% per core, e.g. 800% for 8 cores).
+
+## Paging benchmarks
+
+Allocates 3x the memory limit, forces swap, measures random read latency (CCDF)
+and realloc+touch latency from a swapped pool.
+
+```sh
+systemd-run --user -p MemoryMax=512M -p MemorySwapMax=4G -p CPUQuota=1600% \
+  --wait --pipe "$BENCH" -- --paging
+```
+
+For heavier swap pressure:
+
+```sh
+systemd-run --user -p MemoryMax=128M -p MemorySwapMax=4G -p CPUQuota=1600% \
+  --wait --pipe "$BENCH" -- --paging
+```
+
+## What to look at
+
+* **lgalloc vs sysalloc+touch**: the main comparison.
+  lgalloc reuses faulted pages; the system allocator mmaps/munmaps on each cycle.
+* **sysalloc+touch vs sysalloc+nohuge+touch**: quantifies THP benefit for the system allocator.
+  If the host has THP=`never`, these should be similar.
+* **Scaling**: lgalloc should scale linearly (lock-free work-stealing);
+  sysalloc and mmap degrade due to kernel mmap_lock contention.
+* **Paging CCDF**: bimodal distribution — resident pages (µs) vs swap-in (ms).
+  The tail shows swap I/O latency of the target host's storage.
+* **realloc+touch from swapped pool**: lgalloc recycles virtual addresses without syscalls,
+  so the cost is just page faults, not mmap+fault.
+
+## THP configuration
+
+Check:
+
+```sh
+cat /sys/kernel/mm/transparent_hugepage/enabled
+```
+
+* `always` — THP on all anonymous mappings (lgalloc and sysalloc both benefit)
+* `madvise` — THP only for regions with MADV_HUGEPAGE (lgalloc benefits, sysalloc does not)
+* `never` — no THP (lgalloc's MADV_HUGEPAGE hint is a no-op, warns once)
+
+The `sysalloc+nohuge` variants force 4K pages via MADV_NOHUGEPAGE regardless of this setting.

--- a/BENCH.md
+++ b/BENCH.md
@@ -57,6 +57,74 @@ systemd-run --user -p MemoryMax=128M -p MemorySwapMax=4G -p CPUQuota=1600% \
 * **realloc+touch from swapped pool**: lgalloc recycles virtual addresses without syscalls,
   so the cost is just page faults, not mmap+fault.
 
+## Ratio sweep
+
+Fixes a working set size and varies the cgroup RAM limit to explore the
+relationship between resident-to-swap ratio and latency.
+
+```sh
+for RAM in 4096 2048 1024 512 256; do
+  SWAP=$((8192 - RAM))
+  systemd-run --user \
+    -p MemoryMax=${RAM}M -p MemorySwapMax=${SWAP}M -p CPUQuota=1600% \
+    --wait --pipe "$BENCH" -- --ratio-sweep --total-mib 4096
+done
+```
+
+### Findings (16-vCPU, EBS-backed instance)
+
+**Random reads collapse as soon as data spills to swap.**
+At 1 thread with a 4 GiB working set:
+
+| RAM    | Ratio | ops/s   | p50    | p99    |
+|--------|-------|---------|--------|--------|
+| 4096M  | 1:1   | 232,041 | 238ns  | 632ns  |
+| 2048M  | 1:2   |     156 | 326µs  | 132ms  |
+|  512M  | 1:8   |      93 | 471µs  | 139ms  |
+|  256M  | 1:16  |     144 | 470µs  | 132ms  |
+
+Once swapping, throughput is dominated by per-page swap-in latency (~130 ms p99),
+and the exact ratio matters little.
+
+**Realloc+touch is unaffected by swap pressure.**
+lgalloc recycles the same virtual pages; the kernel keeps the hot working page
+resident since it is touched immediately after dealloc:
+
+| RAM    | Ratio | ops/s   | p50   |
+|--------|-------|---------|-------|
+| 4096M  | 1:1   | 461,636 | 2.2µs |
+|  512M  | 1:8   | 461,323 | 2.2µs |
+
+Scaling is near-linear up to 16 threads (~7 M ops/s) at every ratio.
+
+### madvise strategy experiments (1 thread, 512 M RAM / 4 GiB working set)
+
+| Strategy              | ops/s | p50    | p99    | p999   | max    |
+|-----------------------|-------|--------|--------|--------|--------|
+| baseline              | 2,155 | 468µs  | 777µs  | 2.3ms  | 209ms  |
+| MADV_RANDOM           | 2,334 | 497µs  | 738µs  | 1.1ms  | 4.4ms  |
+| MADV_SEQUENTIAL       | 2,363 | 498µs  | 729µs  | 925µs  | 2.8ms  |
+| prefetch (32 ahead)   | 3,618 | 322µs  | 503µs  | 1.6ms  | 19ms   |
+| batch8+WILLNEED       | 3,724 | 314µs  | 562µs  | 949µs  | 2.2ms  |
+| batch32+WILLNEED      | 3,605 | 319µs  | 520µs  | 790µs  | 2.9ms  |
+| batch128+WILLNEED     | 3,764 | 1.3µs  | 445µs  | 637µs  | 10ms   |
+| MADV_RANDOM+pf (8thr) | 7,032 | 377ns  | 15.3ms | 30ms   | 263ms  |
+
+* **MADV_RANDOM/SEQUENTIAL** barely help (~8%). Default readahead is already
+  small for random patterns and swap I/O is seek-dominated.
+* **MADV_WILLNEED prefetch** is the clear winner: +68% throughput, p50 drops
+  from 468 µs → 322 µs. A prefetch thread (or batch WILLNEED) issues swap-in
+  requests ahead of time, overlapping I/O with computation.
+* **batch128+WILLNEED** achieves a **1.3 µs p50** because most pages are already
+  resident by the time the reader reaches them.
+* **MADV_RANDOM + prefetch at 8 threads** reaches 7,032 ops/s (2× baseline),
+  the best multi-threaded result. Disabling kernel readahead avoids wasted I/O
+  while explicit prefetch keeps the pipeline full.
+* No strategy degrades the all-fits case (~230K ops/s at 1 thread).
+
+These results motivate the `prefetch_hint` API: callers who know their access
+pattern can issue MADV_WILLNEED on specific page ranges ahead of time.
+
 ## THP configuration
 
 Check:

--- a/BENCH.md
+++ b/BENCH.md
@@ -71,33 +71,65 @@ for RAM in 4096 2048 1024 512 256; do
 done
 ```
 
-### Findings (16-vCPU, EBS-backed instance)
+### Findings — EBS vs NVMe swap (16-vCPU r6gd, THP=madvise)
 
-**Random reads collapse as soon as data spills to swap.**
-At 1 thread with a 4 GiB working set:
+#### Random reads (1 thread, 4 GiB working set)
 
-| RAM    | Ratio | ops/s   | p50    | p99    |
-|--------|-------|---------|--------|--------|
-| 4096M  | 1:1   | 232,041 | 238ns  | 632ns  |
-| 2048M  | 1:2   |     156 | 326µs  | 132ms  |
-|  512M  | 1:8   |      93 | 471µs  | 139ms  |
-|  256M  | 1:16  |     144 | 470µs  | 132ms  |
+| RAM    | Ratio | EBS ops/s | NVMe ops/s | NVMe p50 | NVMe p99  |
+|--------|-------|-----------|------------|----------|-----------|
+| 4096M  | 1:1   |   232,041 |  1,545,189 |   181ns  |    533ns  |
+| 2048M  | 1:2   |       156 |     23,174 |    75µs  |    241µs  |
+| 1024M  | 1:4   |         — |     16,504 |    77µs  |    167µs  |
+|  512M  | 1:8   |        93 |     12,996 |    78µs  |    251µs  |
+|  256M  | 1:16  |       144 |     12,578 |    77µs  |    242µs  |
 
-Once swapping, throughput is dominated by per-page swap-in latency (~130 ms p99),
-and the exact ratio matters little.
+On EBS, throughput collapsed to ~100 ops/s once swapping, dominated by
+per-page swap-in latency (~130 ms p99). On NVMe, swap-in completes in
+~80 µs (p50) with sub-300 µs p99 — a **100–150× throughput improvement**
+and **~500× p99 improvement**.
 
-**Realloc+touch is unaffected by swap pressure.**
+The ratio still matters on NVMe (23K → 13K from 1:2 → 1:8), but the
+degradation is gradual rather than catastrophic.
+
+Multi-threaded scaling is near-linear on NVMe:
+
+| RAM    | 1 thr    | 4 thr    | 8 thr     | 16 thr    |
+|--------|----------|----------|-----------|-----------|
+| 2048M  |  23,174  |  91,094  |  161,827  |  268,920  |
+|  512M  |  12,996  |  52,354  |   94,063  |  156,873  |
+
+#### Realloc+touch is unaffected by swap pressure
+
 lgalloc recycles the same virtual pages; the kernel keeps the hot working page
 resident since it is touched immediately after dealloc:
 
 | RAM    | Ratio | ops/s   | p50   |
 |--------|-------|---------|-------|
-| 4096M  | 1:1   | 461,636 | 2.2µs |
-|  512M  | 1:8   | 461,323 | 2.2µs |
+| 4096M  | 1:1   | 465,828 | 2.2µs |
+|  512M  | 1:8   | 453,985 | 2.2µs |
 
-Scaling is near-linear up to 16 threads (~7 M ops/s) at every ratio.
+Scaling is near-linear up to 16 threads (~7.8 M ops/s) at every ratio.
 
-### madvise strategy experiments (1 thread, 512 M RAM / 4 GiB working set)
+### Paging benchmark (CCDF)
+
+512 MiB RAM, 1536 MiB allocated (3× overcommit), NVMe swap:
+
+| Metric                 | 1 thread |
+|------------------------|----------|
+| random_read ops/s      |   17,392 |
+| random_read p50        |   76.2µs |
+| random_read p99        |  240.5µs |
+| random_read max        |    3.7ms |
+| realloc+touch ops/s    |  447,291 |
+| realloc+touch p50      |    2.3µs |
+
+CCDF is bimodal: ~50% of reads hit resident pages (< 300 ns), ~50% swap in
+at ~76–87 µs. The tail (p99.9 = 252 µs, max = 3.7 ms) reflects NVMe device
+latency under queue depth, not EBS network round-trips.
+
+### madvise strategy experiments
+
+#### EBS (1 thread, 512 M RAM / 4 GiB working set)
 
 | Strategy              | ops/s | p50    | p99    | p999   | max    |
 |-----------------------|-------|--------|--------|--------|--------|
@@ -110,17 +142,39 @@ Scaling is near-linear up to 16 threads (~7 M ops/s) at every ratio.
 | batch128+WILLNEED     | 3,764 | 1.3µs  | 445µs  | 637µs  | 10ms   |
 | MADV_RANDOM+pf (8thr) | 7,032 | 377ns  | 15.3ms | 30ms   | 263ms  |
 
-* **MADV_RANDOM/SEQUENTIAL** barely help (~8%). Default readahead is already
-  small for random patterns and swap I/O is seek-dominated.
-* **MADV_WILLNEED prefetch** is the clear winner: +68% throughput, p50 drops
-  from 468 µs → 322 µs. A prefetch thread (or batch WILLNEED) issues swap-in
-  requests ahead of time, overlapping I/O with computation.
-* **batch128+WILLNEED** achieves a **1.3 µs p50** because most pages are already
-  resident by the time the reader reaches them.
-* **MADV_RANDOM + prefetch at 8 threads** reaches 7,032 ops/s (2× baseline),
-  the best multi-threaded result. Disabling kernel readahead avoids wasted I/O
-  while explicit prefetch keeps the pipeline full.
-* No strategy degrades the all-fits case (~230K ops/s at 1 thread).
+#### NVMe (1 thread, 512 M RAM / 4 GiB working set)
+
+| Strategy              | ops/s   | p50    | p99    | p999   | max    |
+|-----------------------|---------|--------|--------|--------|--------|
+| baseline              |  12,996 | 78µs   | 251µs  | 298µs  | 5.8ms  |
+| MADV_RANDOM           |  12,725 | 78µs   | 251µs  | 452µs  | 1.9ms  |
+| MADV_SEQUENTIAL       |  12,825 | 77µs   | 250µs  | 279µs  | 817µs  |
+| prefetch (32 ahead)   | 150,411 | 1.5µs  | 33µs   | 109µs  | 23.9ms |
+| batch8+WILLNEED       |  30,362 | 4.4µs  | 162µs  | 219µs  | 402µs  |
+| batch32+WILLNEED      |  78,060 | 837ns  | 147µs  | 164µs  | 412µs  |
+| batch128+WILLNEED     | 136,947 | 846ns  | 31µs   | 135µs  | 330µs  |
+| MADV_RANDOM+pf (8thr) | 241,035 | 1.3µs  | 591µs  | 830µs  | 12ms   |
+
+#### Analysis
+
+* **MADV_RANDOM/SEQUENTIAL** barely help on either storage backend (~2–8%).
+  Default readahead is already small for random patterns.
+* **MADV_WILLNEED prefetch** is the clear winner on both backends, but the
+  benefit is dramatically larger on NVMe: **150K ops/s** (12× baseline) vs
+  3.6K (1.7× baseline) on EBS. NVMe's low latency means the prefetch thread
+  can keep the I/O pipeline full — most pages are already resident by the time
+  the reader reaches them.
+* **batch128+WILLNEED** achieves sub-microsecond p50 on both backends, but
+  NVMe sustains **137K ops/s** vs 3.8K on EBS.
+* **MADV_RANDOM + prefetch at 8 threads** reaches **241K ops/s** on NVMe
+  (19× baseline), approaching the all-resident rate. On EBS the same strategy
+  managed 7K ops/s with a 263 ms max — the network round-trip dominates.
+* No strategy degrades the all-fits case (~1.5M ops/s at 1 thread on NVMe).
+
+**Takeaway**: NVMe instance storage transforms swap from "emergency fallback"
+to a viable tier. With prefetch, swapped data on NVMe approaches DRAM
+throughput for batch workloads. EBS swap is only practical for cold data
+that is rarely accessed.
 
 These results motivate the `prefetch_hint` API: callers who know their access
 pattern can issue MADV_WILLNEED on specific page ranges ahead of time.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,16 +9,14 @@ repository = "https://github.com/antiguru/rust-lgalloc"
 rust-version = "1.72"
 
 [dependencies]
-crossbeam-deque = "0.8.3"
+crossbeam-deque = "0.8.5"
 libc = "0.2"
-memmap2 = "0.5"
 numa_maps = "0.1"
 page_size = "0.6.0"
-tempfile = "3"
-thiserror = "1.0"
+thiserror = "2.0"
 
 [dev-dependencies]
-serial_test = "2.0"
+serial_test = "3.2"
 
 [profile.release]
 debug = 2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lgalloc"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 authors = ["Moritz Hoffmann <antiguru@gmail.com>"]
 description = "Large object allocator"
@@ -11,12 +11,15 @@ rust-version = "1.72"
 [dependencies]
 crossbeam-deque = "0.8.5"
 libc = "0.2"
-numa_maps = "0.1"
 page_size = "0.6.0"
 thiserror = "2.0"
 
 [dev-dependencies]
-serial_test = "3.2"
+hdrhistogram = "7"
+
+[[bench]]
+name = "alloc_bench"
+harness = false
 
 [profile.release]
 debug = 2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lgalloc"
-version = "0.7.0"
+version = "0.6.0"
 edition = "2021"
 authors = ["Moritz Hoffmann <antiguru@gmail.com>"]
 description = "Large object allocator"

--- a/README.md
+++ b/README.md
@@ -44,9 +44,11 @@ requests transparent huge pages (THP) via `MADV_HUGEPAGE`.
 It is size-classed, meaning that it can only allocate memory in power-of-two sized regions, and each region
 is independent of the others. Each region is backed by areas of increasing size.
 
-Anonymous mappings with THP hints allow the kernel to use 2 MiB huge pages, reducing TLB
-pressure for large allocations. The kernel promotes pages to huge pages transparently when
-`/sys/kernel/mm/transparent_hugepage/enabled` is set to `always` or `madvise`.
+On Linux, anonymous mappings with THP hints allow the kernel to use 2 MiB huge pages,
+reducing TLB pressure for large allocations. The kernel promotes pages to huge pages
+transparently when `/sys/kernel/mm/transparent_hugepage/enabled` is set to `always` or
+`madvise`. On macOS ARM, the kernel does not expose a userspace huge page API, so lgalloc
+uses the base 16 KiB page size.
 
 Lgalloc provides a low-level API, but does not expose a high-level interface. Clients are advised to
 implement their own high-level abstractions, such as vectors or other data structures, on top of
@@ -69,6 +71,7 @@ Anonymous mappings have some properties that are not immediately obvious:
 * Memory is not unmapped during normal operation, but can be lazily marked as unused with a
   background thread.
 * On Linux with THP enabled, allocations can benefit from 2 MiB huge pages, reducing TLB misses.
+  On macOS ARM, huge pages are not available and the base 16 KiB page size is used.
 * The library does not consume physical memory when all regions are freed, but pollutes the
   virtual address space because it doesn't unmap regions during normal operation. Mappings are
   unmapped when the global state is dropped.
@@ -104,7 +107,6 @@ Each area can back multiple regions.
 * Fixed-size areas could allow us to move areas between size classes.
 * Reference-counting can determine when an area isn't referenced anymore, although this is not
   trivial because it's a lock-free system.
-* Support superpages on macOS (`VM_FLAGS_SUPERPAGE_SIZE_2MB` via `mach/vm_statistics.h`).
 
 #### License
 

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Each area can back multiple regions.
 * Fixed-size areas could allow us to move areas between size classes.
 * Reference-counting can determine when an area isn't referenced anymore, although this is not
   trivial because it's a lock-free system.
-* Support superpages on macOS (`VM_FLAGS_SUPERPAGE_SIZE_2MB` via `mach/vm_statistics.h`).
+* Superpage support on macOS is untested (uses `VM_FLAGS_SUPERPAGE_SIZE_2MB` with fallback).
 
 #### License
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 lgalloc
 =======
 
-A memory allocator for large objects. Lgalloc stands for large (object) allocator.
+A memory allocator for large objects backed by anonymous mappings with huge page hints.
+Lgalloc stands for large (object) allocator.
 We spell it `lgalloc` and pronounce it el-gee-alloc.
 
 ```toml
@@ -37,76 +38,71 @@ fn main() -> Result<(), lgalloc::AllocError> {
 }
 ```
 
-## Details
+## When to use lgalloc
 
-Lgalloc is a memory allocator that backs allocations with anonymous memory mappings and
-requests transparent huge pages (THP) via `MADV_HUGEPAGE`.
-It is size-classed, meaning that it can only allocate memory in power-of-two sized regions, and each region
-is independent of the others. Each region is backed by areas of increasing size.
+Lgalloc is designed for programs that allocate and recycle many large memory regions (2 MiB+).
+It pools regions by size class and reuses them without returning virtual address space to the kernel, which avoids the `mmap`/`munmap` overhead and kernel `mmap_lock` contention that dominate at high thread counts.
+On Linux, it requests transparent huge pages via `MADV_HUGEPAGE`, reducing TLB misses for large working sets.
 
-On Linux, anonymous mappings with THP hints allow the kernel to use 2 MiB huge pages,
-reducing TLB pressure for large allocations. The kernel promotes pages to huge pages
-transparently when `/sys/kernel/mm/transparent_hugepage/enabled` is set to `always` or
-`madvise`. On macOS ARM, the kernel does not expose a userspace huge page API, so lgalloc
-uses the base 16 KiB page size.
+Lgalloc is a low-level API.
+Callers get a raw pointer, a capacity, and a handle; they are responsible for building higher-level abstractions (vectors, buffers) on top.
 
-Lgalloc provides a low-level API, but does not expose a high-level interface. Clients are advised to
-implement their own high-level abstractions, such as vectors or other data structures, on top of
-lgalloc.
+## Usage constraints
 
-Anonymous mappings have some properties that are not immediately obvious:
-* Allocations do not use physical memory until they are touched.
-* Returning memory is a two-step process. After deallocation, lgalloc can eagerly return
-  physical memory by calling `MADV_DONTNEED`. An optional background worker periodically
-  calls `MADV_FREE` on unused memory regions, which marks pages as lazily reclaimable
-  without immediate zeroing overhead.
-* Interacting with the memory subsystem can cause contention, especially when multiple threads
-  try to interact with the virtual address space at the same time. For example, the `mmap` and
-  `madvise` system calls can contend with each other and with other parts of the program.
+* **No fork.**
+  Anonymous mappings are shared with child processes after `fork`.
+  Two processes writing to the same mapping causes undefined behavior.
+  There is no way to mark mappings as non-inheritable.
+* **No mlock.**
+  Callers must not lock pages (`mlock`) on regions managed by lgalloc, or must unlock them before returning the region.
+  The background worker calls `madvise` on returned regions, which fails on locked pages.
+* **Do not free with another allocator.**
+  Memory obtained from `allocate` must be returned via `deallocate`.
+  Passing the pointer to `free`, `Vec::from_raw_parts` without `ManuallyDrop`, or any other allocator is undefined behavior.
+* **Minimum allocation is 2 MiB.**
+  Size classes range from 2^21 (2 MiB) to 2^36 (64 GiB).
+  Requests below 2 MiB return `AllocError::InvalidSizeClass`.
+* **Capacity may be rounded up.**
+  The returned capacity can be larger than requested because allocations are rounded to power-of-two size classes.
 
-* Lgalloc provides an allocator for power-of-two sized memory regions, with an optional dampener.
-* The requested capacity can be rounded up to a larger capacity.
-* The memory can be repurposed, for example to back a vector, however, the caller needs to be
-  careful never to free the memory using another allocator.
-* Memory is not unmapped during normal operation, but can be lazily marked as unused with a
-  background thread.
-* On Linux with THP enabled, allocations can benefit from 2 MiB huge pages, reducing TLB misses.
-  On macOS ARM, huge pages are not available and the base 16 KiB page size is used.
-* The library does not consume physical memory when all regions are freed, but pollutes the
-  virtual address space because it doesn't unmap regions during normal operation. Mappings are
-  unmapped when the global state is dropped.
-* Generally, use at your own risk because nobody should write a memory allocator.
-* Performance seems to be reasonable, similar to the system allocator when not touching the data,
-  and faster when touching the data. The reason is that this library does not unmap its regions.
+## Thread safety
 
+`Handle` is `Send` and `Sync`.
+Allocations can be made on one thread and freed on another.
+Each thread maintains a local cache; the global pool uses lock-free work-stealing to redistribute regions.
 
-The allocator tries to minimize contention. It relies on thread-local allocations and a
-work-stealing pattern to move allocations between threads. Each size class acts as its own
-allocator. However, some system calls can contend on mapping objects, which is why reclamation
-can cause contention.
+## How it works
 
-We use the term region for a power-of-two sized allocation, and area for a contiguous allocations.
-Each area can back multiple regions.
+Lgalloc is size-classed: each power-of-two size from 2 MiB to 64 GiB has its own pool.
+Within a size class, contiguous *areas* of increasing size back individual *regions*.
 
-* Each thread maintains a bounded cache of regions.
-* If on allocation the cache is empty, it checks the global pool first, and then other threads.
-* The global pool has a dirty and clean variant. Dirty contains allocations that were recently
-  recycled, and clean contains allocations that we marked as not needed/removed to the OS.
-* An optional background worker periodically moves allocations from dirty to clean.
-* Lgalloc makes heavy use of `crossbeam-deque`, which provides a lock-free work stealing API.
-* Refilling areas is a synchronous operation. It requires creating an anonymous mapping and
-  applying huge page hints. We double the size of the allocation each time a size class is empty.
-* Lgalloc reports metrics about allocations, deallocations, and refills.
+* Each thread maintains a bounded local cache of regions.
+* On allocation, the thread checks its local cache, then the global dirty pool, then the global clean pool, then steals from other threads.
+* On deallocation, the region goes to the local cache or, if full, to the global dirty pool.
+  With `eager_return` enabled, `MADV_DONTNEED` is called before pushing to the global pool.
+* An optional background worker moves dirty regions to the clean pool by calling `MADV_FREE` (Linux) or `MADV_DONTNEED` (other platforms), which marks pages as lazily reclaimable.
+* When all pools are empty, lgalloc creates a new area via `mmap(MAP_ANONYMOUS)` and applies `MADV_HUGEPAGE`.
+  Area sizes double on each refill, controlled by the `growth_dampener` config.
+* Regions are never unmapped during normal operation.
+  This avoids `munmap` syscall overhead but grows virtual address space.
+  Areas are unmapped when the global state is dropped (process exit).
+
+## Platform notes
+
+* **Linux**: requests transparent huge pages via `MADV_HUGEPAGE`.
+  The kernel uses 2 MiB pages when `/sys/kernel/mm/transparent_hugepage/enabled` is `always` or `madvise`.
+  If THP is disabled, the hint is silently ignored (one warning on stderr).
+* **macOS ARM**: the kernel does not expose a userspace huge page API.
+  Lgalloc uses the base 16 KiB page size.
 
 ## To do
 
 * Testing is very limited.
-* Allocating areas of doubling sizes seems to stress the `mmap` system call. Consider a different
-  strategy, such as constant-sized blocks or a limit on what areas we allocate. There's probably
-  a trade-off between area size and number of areas.
+* Allocating areas of doubling sizes seems to stress the `mmap` system call.
+  Consider a different strategy, such as constant-sized blocks or a limit on what areas we allocate.
+  There's probably a trade-off between area size and number of areas.
 * Fixed-size areas could allow us to move areas between size classes.
-* Reference-counting can determine when an area isn't referenced anymore, although this is not
-  trivial because it's a lock-free system.
+* Reference-counting can determine when an area isn't referenced anymore, although this is not trivial because it's a lock-free system.
 
 #### License
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ We spell it `lgalloc` and pronounce it el-gee-alloc.
 
 ```toml
 [dependencies]
-lgalloc = "0.6"
+lgalloc = "0.7"
 ```
 
 ## Example
@@ -16,8 +16,7 @@ use std::mem::ManuallyDrop;
 fn main() -> Result<(), lgalloc::AllocError> {
   lgalloc::lgalloc_set_config(
     lgalloc::LgAlloc::new()
-      .enable()
-      .with_path(std::env::temp_dir()),
+      .enable(),
   );
 
   // Allocate memory
@@ -40,58 +39,48 @@ fn main() -> Result<(), lgalloc::AllocError> {
 
 ## Details
 
-Lgalloc is a memory allocator that backs allocations with memory-mapped sparse files.
+Lgalloc is a memory allocator that backs allocations with anonymous memory mappings and
+requests transparent huge pages (THP) via `MADV_HUGEPAGE`.
 It is size-classed, meaning that it can only allocate memory in power-of-two sized regions, and each region
-is independent of the others. Each region is backed by files of increasing size.
+is independent of the others. Each region is backed by areas of increasing size.
 
-Memory mapped files allow the operating system to evict pages from the page cache under memory pressure,
-thus enabling some form of paging without using swap space. This is useful in environments where
-swapping is not available (e.g, Kubernetes), or where the application wants to retain control over
-which pages can be evicted.
+Anonymous mappings with THP hints allow the kernel to use 2 MiB huge pages, reducing TLB
+pressure for large allocations. The kernel promotes pages to huge pages transparently when
+`/sys/kernel/mm/transparent_hugepage/enabled` is set to `always` or `madvise`.
 
 Lgalloc provides a low-level API, but does not expose a high-level interface. Clients are advised to
 implement their own high-level abstractions, such as vectors or other data structures, on top of
 lgalloc.
 
-Memory mapped files have some properties that are not immediately obvious, and sometimes depend on the
-particular configuration of the operating system. The most important ones are:
-- Allocations do not use physical memory until they are touched. Once touched, they use physical memory
-  and equivalent space on disk. Linux allocates space on disk eagerly, but other operating systems
-  might not. This means that touching memory can cause I/O operations, which can be slow.
-- Returning memory is a two-step process. After deallocation, lgalloc tries to free the physical memory
-  by calling `MADV_DONTNEED`. It's not entirely clear what Linux does with this, but it seems to
-  remove the pages from the page cache, while leaving the disk allocation intact. Lgalloc offers an
-  optional background worker that periodically calls `MADV_FREE` on unused memory regions. This
-  punches holes into the underlying file, which allows the OS to reclaim disk space. Note that this
-  causes I/O operations, which can be slow.
-- Interacting with the memory subsystem can cause contention, especially when multiple threads
-  try to interact with the virtual address space at the same time. For example, reading the
-  `/proc/self/numa_maps` file can cause contention, as can the `mmap` and `madvise` system calls.
-  Other parts of the program, for example the allocator, might use syscalls that can contend with
-  lgalloc.
+Anonymous mappings have some properties that are not immediately obvious:
+* Allocations do not use physical memory until they are touched.
+* Returning memory is a two-step process. After deallocation, lgalloc can eagerly return
+  physical memory by calling `MADV_DONTNEED`. An optional background worker periodically
+  calls `MADV_FREE` on unused memory regions, which marks pages as lazily reclaimable
+  without immediate zeroing overhead.
+* Interacting with the memory subsystem can cause contention, especially when multiple threads
+  try to interact with the virtual address space at the same time. For example, the `mmap` and
+  `madvise` system calls can contend with each other and with other parts of the program.
 
-- Lgalloc provides an allocator for power-of-two sized memory regions, with an optional dampener.
-- The requested capacity can be rounded up to a larger capacity.
-- The memory can be repurposed, for example to back a vector, however, the caller needs to be
+* Lgalloc provides an allocator for power-of-two sized memory regions, with an optional dampener.
+* The requested capacity can be rounded up to a larger capacity.
+* The memory can be repurposed, for example to back a vector, however, the caller needs to be
   careful never to free the memory using another allocator.
-- Memory is not unmapped, but can be lazily marked as unused with a background thread. The exact
-  options for this still need to be determined.
-- The allocations are mapped from a file, which allows the OS to page without using swap.
-- On Linux, this means it can only handle regular pages (4KiB), the region cannot be mapped
-  with huge pages.
-- The library does not consume physical memory when all regions are freed, but pollutes the
-  virtual address space because it doesn't unmap regions. This is because the library does
-  not keep track what parts of a mapping are still in use. (Its internal structures always
-  require memory.)
-- Generally, use at your own risk because nobody should write a memory allocator.
-- Performance seems to be reasonable, similar to the system allocator when not touching the data,
+* Memory is not unmapped during normal operation, but can be lazily marked as unused with a
+  background thread.
+* On Linux with THP enabled, allocations can benefit from 2 MiB huge pages, reducing TLB misses.
+* The library does not consume physical memory when all regions are freed, but pollutes the
+  virtual address space because it doesn't unmap regions during normal operation. Mappings are
+  unmapped when the global state is dropped.
+* Generally, use at your own risk because nobody should write a memory allocator.
+* Performance seems to be reasonable, similar to the system allocator when not touching the data,
   and faster when touching the data. The reason is that this library does not unmap its regions.
 
 
 The allocator tries to minimize contention. It relies on thread-local allocations and a
 work-stealing pattern to move allocations between threads. Each size class acts as its own
 allocator. However, some system calls can contend on mapping objects, which is why reclamation
-and gathering stats can cause contention.
+can cause contention.
 
 We use the term region for a power-of-two sized allocation, and area for a contiguous allocations.
 Each area can back multiple regions.
@@ -102,10 +91,9 @@ Each area can back multiple regions.
   recycled, and clean contains allocations that we marked as not needed/removed to the OS.
 * An optional background worker periodically moves allocations from dirty to clean.
 * Lgalloc makes heavy use of `crossbeam-deque`, which provides a lock-free work stealing API.
-* Refilling areas is a synchronous operation. It requires to create a file, allocate space, and
-  map its contents. We double the size of the allocation each time a size class is empty.
-* Lgalloc reports metrics about allocations, deallocations, and refills, and about the files it
-  owns, if the platform supports it.
+* Refilling areas is a synchronous operation. It requires creating an anonymous mapping and
+  applying huge page hints. We double the size of the allocation each time a size class is empty.
+* Lgalloc reports metrics about allocations, deallocations, and refills.
 
 ## To do
 
@@ -116,6 +104,7 @@ Each area can back multiple regions.
 * Fixed-size areas could allow us to move areas between size classes.
 * Reference-counting can determine when an area isn't referenced anymore, although this is not
   trivial because it's a lock-free system.
+* Support superpages on macOS (`VM_FLAGS_SUPERPAGE_SIZE_2MB` via `mach/vm_statistics.h`).
 
 #### License
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ We spell it `lgalloc` and pronounce it el-gee-alloc.
 
 ```toml
 [dependencies]
-lgalloc = "0.7"
+lgalloc = "0.6"
 ```
 
 ## Example

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Each area can back multiple regions.
 * Fixed-size areas could allow us to move areas between size classes.
 * Reference-counting can determine when an area isn't referenced anymore, although this is not
   trivial because it's a lock-free system.
-* Superpage support on macOS is untested (uses `VM_FLAGS_SUPERPAGE_SIZE_2MB` with fallback).
+* Support superpages on macOS (`VM_FLAGS_SUPERPAGE_SIZE_2MB` via `mach/vm_statistics.h`).
 
 #### License
 

--- a/benches/alloc_bench.rs
+++ b/benches/alloc_bench.rs
@@ -35,8 +35,8 @@ fn main() {
     let args: Vec<String> = std::env::args().collect();
     let run_paging = args.iter().any(|a| a == "--paging");
     let run_ratio_sweep = args.iter().any(|a| a == "--ratio-sweep");
-    let total_mib: Option<usize> = parse_arg_value(&args, "--total-mib")
-        .and_then(|v| v.parse().ok());
+    let total_mib: Option<usize> =
+        parse_arg_value(&args, "--total-mib").and_then(|v| v.parse().ok());
 
     // Initialize lgalloc once.
     lgalloc::lgalloc_set_config(
@@ -68,10 +68,18 @@ fn main() {
         run_bench("sysalloc", threads, bench_sysalloc);
         run_bench("sysalloc+touch", threads, bench_sysalloc_touch);
         run_bench("sysalloc+nohuge", threads, bench_sysalloc_nohuge);
-        run_bench("sysalloc+nohuge+touch", threads, bench_sysalloc_nohuge_touch);
+        run_bench(
+            "sysalloc+nohuge+touch",
+            threads,
+            bench_sysalloc_nohuge_touch,
+        );
         run_bench("mmap/munmap", threads, bench_mmap);
         run_bench("mmap/munmap+touch", threads, bench_mmap_touch);
-        run_bench("mmap/madvise_dontneed", threads, bench_mmap_madvise_dontneed);
+        run_bench(
+            "mmap/madvise_dontneed",
+            threads,
+            bench_mmap_madvise_dontneed,
+        );
         run_bench("mmap/madvise_free", threads, bench_mmap_madvise_free);
         println!();
     }
@@ -496,7 +504,15 @@ fn run_random_read(
     }
     let elapsed = start.elapsed();
     let hist = shared_hist.combined();
-    print_result(name, threads, mem_limit, total_bytes, ratio_label, elapsed, &hist);
+    print_result(
+        name,
+        threads,
+        mem_limit,
+        total_bytes,
+        ratio_label,
+        elapsed,
+        &hist,
+    );
 }
 
 /// Random read with a dedicated prefetch thread that runs `distance` pages ahead
@@ -579,7 +595,15 @@ fn run_prefetch_read(
     }
     let elapsed = start.elapsed();
     let hist = shared_hist.combined();
-    print_result(name, threads, mem_limit, total_bytes, ratio_label, elapsed, &hist);
+    print_result(
+        name,
+        threads,
+        mem_limit,
+        total_bytes,
+        ratio_label,
+        elapsed,
+        &hist,
+    );
 }
 
 /// Batch prefetch: WILLNEED `batch_size` pages, then read them all, measure total.
@@ -646,7 +670,15 @@ fn run_batch_prefetch_read(
     }
     let elapsed = start.elapsed();
     let hist = shared_hist.combined();
-    print_result(name, threads, mem_limit, total_bytes, ratio_label, elapsed, &hist);
+    print_result(
+        name,
+        threads,
+        mem_limit,
+        total_bytes,
+        ratio_label,
+        elapsed,
+        &hist,
+    );
 }
 
 // --- Ratio sweep benchmark ---
@@ -856,7 +888,13 @@ fn bench_ratio_sweep(total_mib: Option<usize>) {
         let elapsed = start.elapsed();
         let hist = shared_hist.combined();
         print_result(
-            "realloc_touch", 1, mem_limit, total_bytes, &ratio_label, elapsed, &hist,
+            "realloc_touch",
+            1,
+            mem_limit,
+            total_bytes,
+            &ratio_label,
+            elapsed,
+            &hist,
         );
     }
 
@@ -869,9 +907,7 @@ fn bench_ratio_sweep(total_mib: Option<usize>) {
 fn bench_paging(total_mib: Option<usize>) {
     // Read cgroup memory limit to determine how much RAM we have.
     let mem_limit = read_cgroup_memory_limit().unwrap_or(512 << 20);
-    let total_bytes = total_mib
-        .map(|m| m << 20)
-        .unwrap_or(mem_limit * 3);
+    let total_bytes = total_mib.map(|m| m << 20).unwrap_or(mem_limit * 3);
     let num_regions = total_bytes / REGION_SIZE;
 
     println!("=== Paging benchmark ===");

--- a/benches/alloc_bench.rs
+++ b/benches/alloc_bench.rs
@@ -54,18 +54,10 @@ fn main() {
         run_bench("sysalloc", threads, bench_sysalloc);
         run_bench("sysalloc+touch", threads, bench_sysalloc_touch);
         run_bench("sysalloc+nohuge", threads, bench_sysalloc_nohuge);
-        run_bench(
-            "sysalloc+nohuge+touch",
-            threads,
-            bench_sysalloc_nohuge_touch,
-        );
+        run_bench("sysalloc+nohuge+touch", threads, bench_sysalloc_nohuge_touch);
         run_bench("mmap/munmap", threads, bench_mmap);
         run_bench("mmap/munmap+touch", threads, bench_mmap_touch);
-        run_bench(
-            "mmap/madvise_dontneed",
-            threads,
-            bench_mmap_madvise_dontneed,
-        );
+        run_bench("mmap/madvise_dontneed", threads, bench_mmap_madvise_dontneed);
         run_bench("mmap/madvise_free", threads, bench_mmap_madvise_free);
         println!();
     }

--- a/benches/alloc_bench.rs
+++ b/benches/alloc_bench.rs
@@ -1,0 +1,582 @@
+//! Benchmarks comparing lgalloc pooling vs direct mmap/munmap.
+//!
+//! Measures allocation throughput and latency across thread counts.
+//!
+//! Run with:
+//!   cargo bench --bench alloc_bench                # throughput benchmarks
+//!   cargo bench --bench alloc_bench -- --paging    # paging scenario (needs cgroup memory limit)
+
+use std::hint::black_box;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Barrier, Mutex};
+use std::time::{Duration, Instant};
+
+use hdrhistogram::Histogram as HdrHistogram;
+
+const REGION_SIZE: usize = 2 << 20; // 2 MiB
+const WARMUP: Duration = Duration::from_secs(1);
+const MEASURE: Duration = Duration::from_secs(5);
+const THREAD_COUNTS: &[usize] = &[1, 2, 4, 8, 16];
+
+/// Wrapper to make `*mut u8` sendable across threads.
+/// SAFETY: The underlying memory is a valid mmap region that outlives all threads.
+#[derive(Clone, Copy)]
+struct SendPtr(*mut u8);
+unsafe impl Send for SendPtr {}
+unsafe impl Sync for SendPtr {}
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    let run_paging = args.iter().any(|a| a == "--paging");
+
+    // Initialize lgalloc once.
+    lgalloc::lgalloc_set_config(
+        lgalloc::LgAlloc::new()
+            .enable()
+            .growth_dampener(0)
+            .eager_return(false)
+            .with_background_config(lgalloc::BackgroundWorkerConfig {
+                interval: Duration::from_millis(100),
+                clear_bytes: 64 << 20,
+            }),
+    );
+
+    if run_paging {
+        bench_paging();
+        return;
+    }
+
+    print_header();
+
+    for &threads in THREAD_COUNTS {
+        run_bench("lgalloc", threads, bench_lgalloc);
+        run_bench("lgalloc+touch", threads, bench_lgalloc_touch);
+        run_bench("sysalloc", threads, bench_sysalloc);
+        run_bench("sysalloc+touch", threads, bench_sysalloc_touch);
+        run_bench("sysalloc+nohuge", threads, bench_sysalloc_nohuge);
+        run_bench("sysalloc+nohuge+touch", threads, bench_sysalloc_nohuge_touch);
+        run_bench("mmap/munmap", threads, bench_mmap);
+        run_bench("mmap/munmap+touch", threads, bench_mmap_touch);
+        run_bench("mmap/madvise_dontneed", threads, bench_mmap_madvise_dontneed);
+        run_bench("mmap/madvise_free", threads, bench_mmap_madvise_free);
+        println!();
+    }
+}
+
+fn print_header() {
+    println!(
+        "{:<30} {:>6} {:>12} {:>10} {:>10} {:>10} {:>10} {:>10}",
+        "benchmark", "thr", "ops/sec", "avg", "p50", "p99", "p99.9", "max"
+    );
+    println!("{}", "-".repeat(110));
+}
+
+fn format_ns(ns: u64) -> String {
+    if ns < 1_000 {
+        format!("{ns}ns")
+    } else if ns < 1_000_000 {
+        format!("{:.1}us", ns as f64 / 1_000.0)
+    } else if ns < 1_000_000_000 {
+        format!("{:.1}ms", ns as f64 / 1_000_000.0)
+    } else {
+        format!("{:.2}s", ns as f64 / 1_000_000_000.0)
+    }
+}
+
+/// Thread-safe histogram backed by hdrhistogram, sharded per-thread then merged.
+struct SharedHistogram {
+    shards: Mutex<Vec<HdrHistogram<u64>>>,
+}
+
+impl SharedHistogram {
+    fn new() -> Self {
+        Self {
+            shards: Mutex::new(Vec::new()),
+        }
+    }
+
+    /// Create a thread-local recorder. Must be merged back via `merge`.
+    fn recorder() -> HdrHistogram<u64> {
+        // Range: 1ns to 60s, 3 significant digits.
+        HdrHistogram::new_with_bounds(1, 60_000_000_000, 3).unwrap()
+    }
+
+    /// Merge a thread-local histogram into the shared state.
+    fn merge(&self, h: HdrHistogram<u64>) {
+        self.shards.lock().unwrap().push(h);
+    }
+
+    /// Combine all shards into one histogram.
+    fn combined(&self) -> HdrHistogram<u64> {
+        let shards = self.shards.lock().unwrap();
+        let mut combined = Self::recorder();
+        for s in shards.iter() {
+            combined.add(s).unwrap();
+        }
+        combined
+    }
+
+    /// Reset all shards.
+    fn reset(&self) {
+        let mut shards = self.shards.lock().unwrap();
+        for s in shards.iter_mut() {
+            s.reset();
+        }
+    }
+}
+
+/// Print a summary line for a benchmark.
+fn print_summary(name: &str, threads: usize, elapsed: Duration, hist: &HdrHistogram<u64>) {
+    let total = hist.len();
+    let ops_per_sec = total as f64 / elapsed.as_secs_f64();
+    let avg_ns = hist.mean() as u64;
+
+    println!(
+        "{:<30} {:>6} {:>12.0} {:>10} {:>10} {:>10} {:>10} {:>10}",
+        name,
+        threads,
+        ops_per_sec,
+        format_ns(avg_ns),
+        format_ns(hist.value_at_quantile(0.5)),
+        format_ns(hist.value_at_quantile(0.99)),
+        format_ns(hist.value_at_quantile(0.999)),
+        format_ns(hist.max()),
+    );
+}
+
+/// Print a CCDF table for a histogram.
+fn print_ccdf(name: &str, hist: &HdrHistogram<u64>) {
+    let total = hist.len();
+    if total == 0 {
+        return;
+    }
+    println!("\n  CCDF for {name} ({total} samples):");
+    println!("  {:>12}  {:>10}  {:>10}", "latency", "P(X>x)", "count>=");
+
+    // Walk percentiles to produce CCDF: P(X > x) = 1 - CDF(x)
+    let quantiles = [
+        0.0, 0.25, 0.50, 0.75, 0.90, 0.95, 0.99, 0.999, 0.9999, 0.99999, 1.0,
+    ];
+    for &q in &quantiles {
+        let v = hist.value_at_quantile(q);
+        let count_above = total - hist.count_between(0, v);
+        let frac_above = count_above as f64 / total as f64;
+        println!(
+            "  {:>12}  {:>10.6}  {:>10}",
+            format_ns(v),
+            frac_above,
+            count_above,
+        );
+    }
+}
+
+/// Run a benchmark with the given thread count and print results.
+fn run_bench(name: &str, threads: usize, f: fn(&AtomicBool, &mut HdrHistogram<u64>)) {
+    let running = Arc::new(AtomicBool::new(true));
+    let shared_hist = Arc::new(SharedHistogram::new());
+    let barrier = Arc::new(Barrier::new(threads + 1));
+
+    let handles: Vec<_> = (0..threads)
+        .map(|_| {
+            let running = Arc::clone(&running);
+            let shared_hist = Arc::clone(&shared_hist);
+            let barrier = Arc::clone(&barrier);
+            std::thread::spawn(move || {
+                let mut hist = SharedHistogram::recorder();
+                barrier.wait();
+                f(&running, &mut hist);
+                shared_hist.merge(hist);
+            })
+        })
+        .collect();
+
+    // Warmup phase
+    barrier.wait();
+    std::thread::sleep(WARMUP);
+    shared_hist.reset();
+
+    // Measurement phase
+    let start = Instant::now();
+    std::thread::sleep(MEASURE);
+    running.store(false, Ordering::SeqCst);
+
+    for h in handles {
+        h.join().unwrap();
+    }
+    let elapsed = start.elapsed();
+
+    let hist = shared_hist.combined();
+    print_summary(name, threads, elapsed, &hist);
+}
+
+// --- Benchmark functions ---
+
+fn bench_lgalloc(running: &AtomicBool, hist: &mut HdrHistogram<u64>) {
+    while running.load(Ordering::Relaxed) {
+        let start = Instant::now();
+        let (_ptr, _cap, handle) = lgalloc::allocate::<u8>(REGION_SIZE).unwrap();
+        black_box(&handle);
+        lgalloc::deallocate(handle);
+        let _ = hist.record(start.elapsed().as_nanos() as u64);
+    }
+}
+
+fn bench_lgalloc_touch(running: &AtomicBool, hist: &mut HdrHistogram<u64>) {
+    while running.load(Ordering::Relaxed) {
+        let start = Instant::now();
+        let (ptr, cap, handle) = lgalloc::allocate::<u8>(REGION_SIZE).unwrap();
+        let slice = unsafe { std::slice::from_raw_parts_mut(ptr.as_ptr(), cap) };
+        for i in (0..slice.len()).step_by(4096) {
+            unsafe { std::ptr::write_volatile(&mut slice[i], 1) };
+        }
+        black_box(slice);
+        lgalloc::deallocate(handle);
+        let _ = hist.record(start.elapsed().as_nanos() as u64);
+    }
+}
+
+/// System allocator (glibc malloc). For 2 MiB, glibc uses mmap internally.
+/// With THP=always, khugepaged may coalesce pages into huge pages in the background.
+fn bench_sysalloc(running: &AtomicBool, hist: &mut HdrHistogram<u64>) {
+    let layout = std::alloc::Layout::from_size_align(REGION_SIZE, 4096).unwrap();
+    while running.load(Ordering::Relaxed) {
+        let start = Instant::now();
+        let ptr = unsafe { std::alloc::alloc(layout) };
+        assert!(!ptr.is_null());
+        black_box(ptr);
+        unsafe { std::alloc::dealloc(ptr, layout) };
+        let _ = hist.record(start.elapsed().as_nanos() as u64);
+    }
+}
+
+fn bench_sysalloc_touch(running: &AtomicBool, hist: &mut HdrHistogram<u64>) {
+    let layout = std::alloc::Layout::from_size_align(REGION_SIZE, 4096).unwrap();
+    while running.load(Ordering::Relaxed) {
+        let start = Instant::now();
+        let ptr = unsafe { std::alloc::alloc(layout) };
+        assert!(!ptr.is_null());
+        let slice = unsafe { std::slice::from_raw_parts_mut(ptr, REGION_SIZE) };
+        for i in (0..REGION_SIZE).step_by(4096) {
+            unsafe { std::ptr::write_volatile(&mut slice[i], 1) };
+        }
+        black_box(slice);
+        unsafe { std::alloc::dealloc(ptr, layout) };
+        let _ = hist.record(start.elapsed().as_nanos() as u64);
+    }
+}
+
+/// System allocator with MADV_NOHUGEPAGE to force 4K pages and prevent
+/// khugepaged background coalescing.
+fn bench_sysalloc_nohuge(running: &AtomicBool, hist: &mut HdrHistogram<u64>) {
+    let layout = std::alloc::Layout::from_size_align(REGION_SIZE, 4096).unwrap();
+    while running.load(Ordering::Relaxed) {
+        let start = Instant::now();
+        let ptr = unsafe { std::alloc::alloc(layout) };
+        assert!(!ptr.is_null());
+        #[cfg(target_os = "linux")]
+        unsafe {
+            libc::madvise(ptr.cast(), REGION_SIZE, libc::MADV_NOHUGEPAGE);
+        }
+        black_box(ptr);
+        unsafe { std::alloc::dealloc(ptr, layout) };
+        let _ = hist.record(start.elapsed().as_nanos() as u64);
+    }
+}
+
+fn bench_sysalloc_nohuge_touch(running: &AtomicBool, hist: &mut HdrHistogram<u64>) {
+    let layout = std::alloc::Layout::from_size_align(REGION_SIZE, 4096).unwrap();
+    while running.load(Ordering::Relaxed) {
+        let start = Instant::now();
+        let ptr = unsafe { std::alloc::alloc(layout) };
+        assert!(!ptr.is_null());
+        #[cfg(target_os = "linux")]
+        unsafe {
+            libc::madvise(ptr.cast(), REGION_SIZE, libc::MADV_NOHUGEPAGE);
+        }
+        let slice = unsafe { std::slice::from_raw_parts_mut(ptr, REGION_SIZE) };
+        for i in (0..REGION_SIZE).step_by(4096) {
+            unsafe { std::ptr::write_volatile(&mut slice[i], 1) };
+        }
+        black_box(slice);
+        unsafe { std::alloc::dealloc(ptr, layout) };
+        let _ = hist.record(start.elapsed().as_nanos() as u64);
+    }
+}
+
+fn bench_mmap(running: &AtomicBool, hist: &mut HdrHistogram<u64>) {
+    while running.load(Ordering::Relaxed) {
+        let start = Instant::now();
+        let ptr = unsafe {
+            libc::mmap(
+                std::ptr::null_mut(),
+                REGION_SIZE,
+                libc::PROT_READ | libc::PROT_WRITE,
+                libc::MAP_PRIVATE | libc::MAP_ANONYMOUS,
+                -1,
+                0,
+            )
+        };
+        assert_ne!(ptr, libc::MAP_FAILED);
+        black_box(ptr);
+        unsafe { libc::munmap(ptr, REGION_SIZE) };
+        let _ = hist.record(start.elapsed().as_nanos() as u64);
+    }
+}
+
+fn bench_mmap_touch(running: &AtomicBool, hist: &mut HdrHistogram<u64>) {
+    while running.load(Ordering::Relaxed) {
+        let start = Instant::now();
+        let ptr = unsafe {
+            libc::mmap(
+                std::ptr::null_mut(),
+                REGION_SIZE,
+                libc::PROT_READ | libc::PROT_WRITE,
+                libc::MAP_PRIVATE | libc::MAP_ANONYMOUS,
+                -1,
+                0,
+            )
+        };
+        assert_ne!(ptr, libc::MAP_FAILED);
+        let slice = unsafe { std::slice::from_raw_parts_mut(ptr.cast::<u8>(), REGION_SIZE) };
+        for i in (0..REGION_SIZE).step_by(4096) {
+            unsafe { std::ptr::write_volatile(&mut slice[i], 1) };
+        }
+        black_box(slice);
+        unsafe { libc::munmap(ptr, REGION_SIZE) };
+        let _ = hist.record(start.elapsed().as_nanos() as u64);
+    }
+}
+
+fn bench_mmap_madvise_dontneed(running: &AtomicBool, hist: &mut HdrHistogram<u64>) {
+    let ptr = unsafe {
+        libc::mmap(
+            std::ptr::null_mut(),
+            REGION_SIZE,
+            libc::PROT_READ | libc::PROT_WRITE,
+            libc::MAP_PRIVATE | libc::MAP_ANONYMOUS,
+            -1,
+            0,
+        )
+    };
+    assert_ne!(ptr, libc::MAP_FAILED);
+
+    while running.load(Ordering::Relaxed) {
+        let start = Instant::now();
+        unsafe { libc::madvise(ptr, REGION_SIZE, libc::MADV_DONTNEED) };
+        let slice = unsafe { std::slice::from_raw_parts_mut(ptr.cast::<u8>(), REGION_SIZE) };
+        for i in (0..REGION_SIZE).step_by(4096) {
+            unsafe { std::ptr::write_volatile(&mut slice[i], 1) };
+        }
+        black_box(slice);
+        let _ = hist.record(start.elapsed().as_nanos() as u64);
+    }
+    unsafe { libc::munmap(ptr, REGION_SIZE) };
+}
+
+fn bench_mmap_madvise_free(running: &AtomicBool, hist: &mut HdrHistogram<u64>) {
+    let ptr = unsafe {
+        libc::mmap(
+            std::ptr::null_mut(),
+            REGION_SIZE,
+            libc::PROT_READ | libc::PROT_WRITE,
+            libc::MAP_PRIVATE | libc::MAP_ANONYMOUS,
+            -1,
+            0,
+        )
+    };
+    assert_ne!(ptr, libc::MAP_FAILED);
+
+    while running.load(Ordering::Relaxed) {
+        let start = Instant::now();
+        unsafe { libc::madvise(ptr, REGION_SIZE, libc::MADV_FREE) };
+        let slice = unsafe { std::slice::from_raw_parts_mut(ptr.cast::<u8>(), REGION_SIZE) };
+        for i in (0..REGION_SIZE).step_by(4096) {
+            unsafe { std::ptr::write_volatile(&mut slice[i], 1) };
+        }
+        black_box(slice);
+        let _ = hist.record(start.elapsed().as_nanos() as u64);
+    }
+    unsafe { libc::munmap(ptr, REGION_SIZE) };
+}
+
+// --- Paging benchmark ---
+// Allocates more memory than available RAM, touches all of it, then measures
+// random access latency as pages get swapped in/out.
+
+fn bench_paging() {
+    // Read cgroup memory limit to determine how much RAM we have.
+    let mem_limit = read_cgroup_memory_limit().unwrap_or(512 << 20);
+    // Allocate 3x the memory limit to guarantee swap pressure.
+    let total_bytes = mem_limit * 3;
+    let num_regions = total_bytes / REGION_SIZE;
+
+    println!("=== Paging benchmark ===");
+    println!(
+        "cgroup memory limit: {} MiB, allocating: {} MiB ({} x {} MiB regions)",
+        mem_limit >> 20,
+        total_bytes >> 20,
+        num_regions,
+        REGION_SIZE >> 20,
+    );
+
+    // Phase 1: Allocate all regions via lgalloc.
+    let alloc_start = Instant::now();
+    let mut regions: Vec<_> = (0..num_regions)
+        .map(|_| lgalloc::allocate::<u8>(REGION_SIZE).unwrap())
+        .collect();
+    let alloc_elapsed = alloc_start.elapsed();
+    println!(
+        "allocation: {} regions in {:.1}ms",
+        num_regions,
+        alloc_elapsed.as_secs_f64() * 1000.0
+    );
+
+    // Phase 2: Touch all pages sequentially to fault them in (and push to swap).
+    let touch_start = Instant::now();
+    for (ptr, cap, _handle) in &regions {
+        let slice = unsafe { std::slice::from_raw_parts_mut(ptr.as_ptr(), *cap) };
+        for i in (0..slice.len()).step_by(4096) {
+            unsafe { std::ptr::write_volatile(&mut slice[i], 1) };
+        }
+    }
+    let touch_elapsed = touch_start.elapsed();
+    println!(
+        "sequential touch: {} MiB in {:.1}ms ({:.0} MiB/s)",
+        total_bytes >> 20,
+        touch_elapsed.as_secs_f64() * 1000.0,
+        (total_bytes as f64 / (1 << 20) as f64) / touch_elapsed.as_secs_f64(),
+    );
+
+    // Phase 3: Random-access reads across all regions.
+    println!("\n--- random page reads (bimodal: resident vs swapped) ---");
+    print_header();
+
+    for &threads in &[1, 4] {
+        let running = Arc::new(AtomicBool::new(true));
+        let shared_hist = Arc::new(SharedHistogram::new());
+        let barrier = Arc::new(Barrier::new(threads + 1));
+
+        // Build a shared index of all page addresses.
+        let page_addrs: Arc<Vec<SendPtr>> = {
+            let mut addrs = Vec::new();
+            for (ptr, cap, _) in &regions {
+                let base = ptr.as_ptr();
+                for offset in (0..*cap).step_by(4096) {
+                    addrs.push(SendPtr(unsafe { base.add(offset) }));
+                }
+            }
+            Arc::new(addrs)
+        };
+
+        let handles: Vec<_> = (0..threads)
+            .map(|t| {
+                let running = Arc::clone(&running);
+                let shared_hist = Arc::clone(&shared_hist);
+                let barrier = Arc::clone(&barrier);
+                let page_addrs = Arc::clone(&page_addrs);
+                std::thread::spawn(move || {
+                    let mut hist = SharedHistogram::recorder();
+                    barrier.wait();
+                    let n = page_addrs.len();
+                    // Large prime stride for pseudo-random traversal.
+                    let stride = 104_729;
+                    let mut idx = (t * 7919) % n;
+                    while running.load(Ordering::Relaxed) {
+                        let start = Instant::now();
+                        let val = unsafe { std::ptr::read_volatile(page_addrs[idx].0) };
+                        black_box(val);
+                        let _ = hist.record(start.elapsed().as_nanos() as u64);
+                        idx = (idx + stride) % n;
+                    }
+                    shared_hist.merge(hist);
+                })
+            })
+            .collect();
+
+        barrier.wait();
+        std::thread::sleep(Duration::from_millis(500));
+        shared_hist.reset();
+
+        let start = Instant::now();
+        std::thread::sleep(Duration::from_secs(10));
+        running.store(false, Ordering::SeqCst);
+
+        for h in handles {
+            h.join().unwrap();
+        }
+        let elapsed = start.elapsed();
+
+        let hist = shared_hist.combined();
+        print_summary("random_read", threads, elapsed, &hist);
+        if threads == 1 {
+            print_ccdf("random_read (1 thread)", &hist);
+        }
+    }
+
+    // Phase 4: Deallocate half, then alloc+touch in a loop (recycled-but-swapped regions).
+    println!("\n--- deallocate half, reallocate+touch ---");
+    print_header();
+
+    let half = regions.len() / 2;
+    for (_ptr, _cap, handle) in regions.drain(..half) {
+        lgalloc::deallocate(handle);
+    }
+
+    let running = Arc::new(AtomicBool::new(true));
+    let shared_hist = Arc::new(SharedHistogram::new());
+
+    let r2 = Arc::clone(&running);
+    let sh2 = Arc::clone(&shared_hist);
+    let handle = std::thread::spawn(move || {
+        let mut hist = SharedHistogram::recorder();
+        while r2.load(Ordering::Relaxed) {
+            let start = Instant::now();
+            let (ptr, cap, handle) = lgalloc::allocate::<u8>(REGION_SIZE).unwrap();
+            let slice = unsafe { std::slice::from_raw_parts_mut(ptr.as_ptr(), cap) };
+            for i in (0..slice.len()).step_by(4096) {
+                unsafe { std::ptr::write_volatile(&mut slice[i], 1) };
+            }
+            black_box(slice);
+            lgalloc::deallocate(handle);
+            let _ = hist.record(start.elapsed().as_nanos() as u64);
+        }
+        sh2.merge(hist);
+    });
+
+    std::thread::sleep(Duration::from_millis(500));
+    shared_hist.reset();
+
+    let start = Instant::now();
+    std::thread::sleep(Duration::from_secs(10));
+    running.store(false, Ordering::SeqCst);
+    handle.join().unwrap();
+
+    let elapsed = start.elapsed();
+    let hist = shared_hist.combined();
+    print_summary("realloc+touch (swapped)", 1, elapsed, &hist);
+    print_ccdf("realloc+touch (swapped, 1 thread)", &hist);
+
+    // Cleanup
+    for (_ptr, _cap, handle) in regions.drain(..) {
+        lgalloc::deallocate(handle);
+    }
+}
+
+/// Read cgroup v2 memory.max, falling back to cgroup v1.
+fn read_cgroup_memory_limit() -> Option<usize> {
+    // cgroup v2
+    if let Ok(content) = std::fs::read_to_string("/sys/fs/cgroup/memory.max") {
+        if let Ok(limit) = content.trim().parse::<usize>() {
+            return Some(limit);
+        }
+    }
+    // cgroup v1
+    if let Ok(content) = std::fs::read_to_string("/sys/fs/cgroup/memory/memory.limit_in_bytes") {
+        if let Ok(limit) = content.trim().parse::<usize>() {
+            if limit < (1usize << 50) {
+                return Some(limit);
+            }
+        }
+    }
+    None
+}

--- a/benches/alloc_bench.rs
+++ b/benches/alloc_bench.rs
@@ -54,10 +54,18 @@ fn main() {
         run_bench("sysalloc", threads, bench_sysalloc);
         run_bench("sysalloc+touch", threads, bench_sysalloc_touch);
         run_bench("sysalloc+nohuge", threads, bench_sysalloc_nohuge);
-        run_bench("sysalloc+nohuge+touch", threads, bench_sysalloc_nohuge_touch);
+        run_bench(
+            "sysalloc+nohuge+touch",
+            threads,
+            bench_sysalloc_nohuge_touch,
+        );
         run_bench("mmap/munmap", threads, bench_mmap);
         run_bench("mmap/munmap+touch", threads, bench_mmap_touch);
-        run_bench("mmap/madvise_dontneed", threads, bench_mmap_madvise_dontneed);
+        run_bench(
+            "mmap/madvise_dontneed",
+            threads,
+            bench_mmap_madvise_dontneed,
+        );
         run_bench("mmap/madvise_free", threads, bench_mmap_madvise_free);
         println!();
     }

--- a/benches/alloc_bench.rs
+++ b/benches/alloc_bench.rs
@@ -25,9 +25,18 @@ struct SendPtr(*mut u8);
 unsafe impl Send for SendPtr {}
 unsafe impl Sync for SendPtr {}
 
+fn parse_arg_value(args: &[String], flag: &str) -> Option<String> {
+    args.iter()
+        .position(|a| a == flag)
+        .and_then(|i| args.get(i + 1).cloned())
+}
+
 fn main() {
     let args: Vec<String> = std::env::args().collect();
     let run_paging = args.iter().any(|a| a == "--paging");
+    let run_ratio_sweep = args.iter().any(|a| a == "--ratio-sweep");
+    let total_mib: Option<usize> = parse_arg_value(&args, "--total-mib")
+        .and_then(|v| v.parse().ok());
 
     // Initialize lgalloc once.
     lgalloc::lgalloc_set_config(
@@ -41,8 +50,13 @@ fn main() {
             }),
     );
 
+    if run_ratio_sweep {
+        bench_ratio_sweep(total_mib);
+        return;
+    }
+
     if run_paging {
-        bench_paging();
+        bench_paging(total_mib);
         return;
     }
 
@@ -403,11 +417,461 @@ fn bench_mmap_madvise_free(running: &AtomicBool, hist: &mut HdrHistogram<u64>) {
 // Allocates more memory than available RAM, touches all of it, then measures
 // random access latency as pages get swapped in/out.
 
-fn bench_paging() {
+// --- Shared helpers for ratio sweep ---
+
+fn print_result(
+    name: &str,
+    threads: usize,
+    mem_limit: usize,
+    total_bytes: usize,
+    ratio_label: &str,
+    elapsed: Duration,
+    hist: &HdrHistogram<u64>,
+) {
+    println!(
+        "{:<25} ram_mib={}  ws_mib={}  ratio={:<10} thr={:<2}  ops={:<10}  avg={:<10} p50={:<10} p99={:<10} p999={:<10} max={}",
+        name,
+        mem_limit >> 20,
+        total_bytes >> 20,
+        ratio_label,
+        threads,
+        (hist.len() as f64 / elapsed.as_secs_f64()) as u64,
+        format_ns(hist.mean() as u64),
+        format_ns(hist.value_at_quantile(0.5)),
+        format_ns(hist.value_at_quantile(0.99)),
+        format_ns(hist.value_at_quantile(0.999)),
+        format_ns(hist.max()),
+    );
+}
+
+/// Plain random read (no madvise tricks).
+#[allow(clippy::too_many_arguments)]
+fn run_random_read(
+    name: &str,
+    threads: usize,
+    page_addrs: &Arc<Vec<SendPtr>>,
+    measure_secs: u64,
+    warmup_ms: u64,
+    mem_limit: usize,
+    total_bytes: usize,
+    ratio_label: &str,
+) {
+    let running = Arc::new(AtomicBool::new(true));
+    let shared_hist = Arc::new(SharedHistogram::new());
+    let barrier = Arc::new(Barrier::new(threads + 1));
+
+    let handles: Vec<_> = (0..threads)
+        .map(|t| {
+            let running = Arc::clone(&running);
+            let shared_hist = Arc::clone(&shared_hist);
+            let barrier = Arc::clone(&barrier);
+            let page_addrs = Arc::clone(page_addrs);
+            std::thread::spawn(move || {
+                let mut hist = SharedHistogram::recorder();
+                barrier.wait();
+                let n = page_addrs.len();
+                let stride = 104_729;
+                let mut idx = (t * 7919) % n;
+                while running.load(Ordering::Relaxed) {
+                    let start = Instant::now();
+                    let val = unsafe { std::ptr::read_volatile(page_addrs[idx].0) };
+                    black_box(val);
+                    let _ = hist.record(start.elapsed().as_nanos() as u64);
+                    idx = (idx + stride) % n;
+                }
+                shared_hist.merge(hist);
+            })
+        })
+        .collect();
+
+    barrier.wait();
+    std::thread::sleep(Duration::from_millis(warmup_ms));
+    shared_hist.reset();
+
+    let start = Instant::now();
+    std::thread::sleep(Duration::from_secs(measure_secs));
+    running.store(false, Ordering::SeqCst);
+    for h in handles {
+        h.join().unwrap();
+    }
+    let elapsed = start.elapsed();
+    let hist = shared_hist.combined();
+    print_result(name, threads, mem_limit, total_bytes, ratio_label, elapsed, &hist);
+}
+
+/// Random read with a dedicated prefetch thread that runs `distance` pages ahead
+/// issuing MADV_WILLNEED on each page.
+#[allow(clippy::too_many_arguments)]
+fn run_prefetch_read(
+    name: &str,
+    threads: usize,
+    page_addrs: &Arc<Vec<SendPtr>>,
+    measure_secs: u64,
+    warmup_ms: u64,
+    mem_limit: usize,
+    total_bytes: usize,
+    ratio_label: &str,
+    distance: usize,
+) {
+    let running = Arc::new(AtomicBool::new(true));
+    let shared_hist = Arc::new(SharedHistogram::new());
+    // +1 for main thread coordination, +threads for prefetch threads (one per reader)
+    let barrier = Arc::new(Barrier::new(threads * 2 + 1));
+
+    let handles: Vec<_> = (0..threads)
+        .flat_map(|t| {
+            let running_r = Arc::clone(&running);
+            let running_p = Arc::clone(&running);
+            let shared_hist = Arc::clone(&shared_hist);
+            let barrier_r = Arc::clone(&barrier);
+            let barrier_p = Arc::clone(&barrier);
+            let addrs_r = Arc::clone(page_addrs);
+            let addrs_p = Arc::clone(page_addrs);
+            let n = page_addrs.len();
+            let stride = 104_729;
+            let start_idx = (t * 7919) % n;
+
+            // Prefetch thread: runs `distance` steps ahead of the reader.
+            let prefetcher = std::thread::spawn(move || {
+                barrier_p.wait();
+                let mut idx = start_idx;
+                // Jump ahead by `distance` steps.
+                for _ in 0..distance {
+                    idx = (idx + stride) % n;
+                }
+                while running_p.load(Ordering::Relaxed) {
+                    let ptr = addrs_p[idx].0;
+                    unsafe { libc::madvise(ptr.cast(), 4096, libc::MADV_WILLNEED) };
+                    idx = (idx + stride) % n;
+                    // Yield occasionally so we don't spin too far ahead.
+                    std::thread::yield_now();
+                }
+            });
+
+            // Reader thread: same traversal pattern.
+            let reader = std::thread::spawn(move || {
+                let mut hist = SharedHistogram::recorder();
+                barrier_r.wait();
+                let mut idx = start_idx;
+                while running_r.load(Ordering::Relaxed) {
+                    let start = Instant::now();
+                    let val = unsafe { std::ptr::read_volatile(addrs_r[idx].0) };
+                    black_box(val);
+                    let _ = hist.record(start.elapsed().as_nanos() as u64);
+                    idx = (idx + stride) % n;
+                }
+                shared_hist.merge(hist);
+            });
+
+            [prefetcher, reader]
+        })
+        .collect();
+
+    barrier.wait();
+    std::thread::sleep(Duration::from_millis(warmup_ms));
+    shared_hist.reset();
+
+    let start = Instant::now();
+    std::thread::sleep(Duration::from_secs(measure_secs));
+    running.store(false, Ordering::SeqCst);
+    for h in handles {
+        h.join().unwrap();
+    }
+    let elapsed = start.elapsed();
+    let hist = shared_hist.combined();
+    print_result(name, threads, mem_limit, total_bytes, ratio_label, elapsed, &hist);
+}
+
+/// Batch prefetch: WILLNEED `batch_size` pages, then read them all, measure total.
+#[allow(clippy::too_many_arguments)]
+fn run_batch_prefetch_read(
+    name: &str,
+    threads: usize,
+    page_addrs: &Arc<Vec<SendPtr>>,
+    measure_secs: u64,
+    warmup_ms: u64,
+    mem_limit: usize,
+    total_bytes: usize,
+    ratio_label: &str,
+    batch_size: usize,
+) {
+    let running = Arc::new(AtomicBool::new(true));
+    let shared_hist = Arc::new(SharedHistogram::new());
+    let barrier = Arc::new(Barrier::new(threads + 1));
+
+    let handles: Vec<_> = (0..threads)
+        .map(|t| {
+            let running = Arc::clone(&running);
+            let shared_hist = Arc::clone(&shared_hist);
+            let barrier = Arc::clone(&barrier);
+            let page_addrs = Arc::clone(page_addrs);
+            std::thread::spawn(move || {
+                let mut hist = SharedHistogram::recorder();
+                barrier.wait();
+                let n = page_addrs.len();
+                let stride = 104_729;
+                let mut idx = (t * 7919) % n;
+                while running.load(Ordering::Relaxed) {
+                    // Phase 1: issue WILLNEED for the whole batch.
+                    let batch_start_idx = idx;
+                    for _ in 0..batch_size {
+                        let ptr = page_addrs[idx].0;
+                        unsafe { libc::madvise(ptr.cast(), 4096, libc::MADV_WILLNEED) };
+                        idx = (idx + stride) % n;
+                    }
+                    // Phase 2: read them all, measuring per-page latency.
+                    idx = batch_start_idx;
+                    for _ in 0..batch_size {
+                        let start = Instant::now();
+                        let val = unsafe { std::ptr::read_volatile(page_addrs[idx].0) };
+                        black_box(val);
+                        let _ = hist.record(start.elapsed().as_nanos() as u64);
+                        idx = (idx + stride) % n;
+                    }
+                }
+                shared_hist.merge(hist);
+            })
+        })
+        .collect();
+
+    barrier.wait();
+    std::thread::sleep(Duration::from_millis(warmup_ms));
+    shared_hist.reset();
+
+    let start = Instant::now();
+    std::thread::sleep(Duration::from_secs(measure_secs));
+    running.store(false, Ordering::SeqCst);
+    for h in handles {
+        h.join().unwrap();
+    }
+    let elapsed = start.elapsed();
+    let hist = shared_hist.combined();
+    print_result(name, threads, mem_limit, total_bytes, ratio_label, elapsed, &hist);
+}
+
+// --- Ratio sweep benchmark ---
+// Allocates a fixed working set, touches it all into swap, then measures
+// random read and realloc+touch at the current cgroup memory ratio.
+// Designed to be invoked repeatedly with different MemoryMax values.
+
+fn bench_ratio_sweep(total_mib: Option<usize>) {
+    let mem_limit = read_cgroup_memory_limit().unwrap_or(512 << 20);
+    let total_bytes = total_mib.map(|m| m << 20).unwrap_or(4 << 30);
+    let num_regions = total_bytes / REGION_SIZE;
+    let ratio_label = if mem_limit >= total_bytes {
+        "all fits".to_string()
+    } else {
+        format!("1:{:.1}", total_bytes as f64 / mem_limit as f64)
+    };
+
+    eprintln!(
+        "=== ratio sweep: RAM={} MiB, working_set={} MiB ({} regions), ratio={} ===",
+        mem_limit >> 20,
+        total_bytes >> 20,
+        num_regions,
+        ratio_label,
+    );
+
+    // Phase 1: Allocate and touch everything to push into swap.
+    let mut regions: Vec<_> = (0..num_regions)
+        .map(|_| lgalloc::allocate::<u8>(REGION_SIZE).unwrap())
+        .collect();
+
+    let touch_start = Instant::now();
+    for (ptr, cap, _handle) in &regions {
+        let slice = unsafe { std::slice::from_raw_parts_mut(ptr.as_ptr(), *cap) };
+        for i in (0..slice.len()).step_by(4096) {
+            unsafe { std::ptr::write_volatile(&mut slice[i], 1) };
+        }
+    }
+    let touch_elapsed = touch_start.elapsed();
+    eprintln!(
+        "  touch: {:.1}ms ({:.0} MiB/s)",
+        touch_elapsed.as_secs_f64() * 1000.0,
+        (total_bytes as f64 / (1 << 20) as f64) / touch_elapsed.as_secs_f64(),
+    );
+
+    // Phase 2: madvise strategy experiments for random reads.
+    let measure_secs = 10;
+    let warmup_ms = 500;
+
+    let page_addrs: Arc<Vec<SendPtr>> = {
+        let mut addrs = Vec::new();
+        for (ptr, cap, _) in &regions {
+            let base = ptr.as_ptr();
+            for offset in (0..*cap).step_by(4096) {
+                addrs.push(SendPtr(unsafe { base.add(offset) }));
+            }
+        }
+        Arc::new(addrs)
+    };
+
+    // Helper: apply madvise to all regions.
+    let madvise_all = |advice: libc::c_int| {
+        for (ptr, cap, _) in &regions {
+            unsafe { libc::madvise(ptr.as_ptr().cast(), *cap, advice) };
+        }
+    };
+
+    // --- Strategy A: baseline random reads (default kernel policy) ---
+    for &threads in THREAD_COUNTS {
+        run_random_read(
+            "rand_baseline",
+            threads,
+            &page_addrs,
+            measure_secs,
+            warmup_ms,
+            mem_limit,
+            total_bytes,
+            &ratio_label,
+        );
+    }
+
+    // --- Strategy B: MADV_RANDOM — tell kernel our access is random, disable readahead ---
+    #[cfg(target_os = "linux")]
+    {
+        madvise_all(libc::MADV_RANDOM);
+        for &threads in THREAD_COUNTS {
+            run_random_read(
+                "rand+RANDOM",
+                threads,
+                &page_addrs,
+                measure_secs,
+                warmup_ms,
+                mem_limit,
+                total_bytes,
+                &ratio_label,
+            );
+        }
+        // Reset to default.
+        madvise_all(libc::MADV_NORMAL);
+    }
+
+    // --- Strategy C: MADV_SEQUENTIAL — aggressive readahead (counterintuitive for random) ---
+    #[cfg(target_os = "linux")]
+    {
+        madvise_all(libc::MADV_SEQUENTIAL);
+        for &threads in THREAD_COUNTS {
+            run_random_read(
+                "rand+SEQUENTIAL",
+                threads,
+                &page_addrs,
+                measure_secs,
+                warmup_ms,
+                mem_limit,
+                total_bytes,
+                &ratio_label,
+            );
+        }
+        madvise_all(libc::MADV_NORMAL);
+    }
+
+    // --- Strategy D: prefetch thread runs ahead with MADV_WILLNEED ---
+    for &threads in THREAD_COUNTS {
+        run_prefetch_read(
+            "rand+prefetch",
+            threads,
+            &page_addrs,
+            measure_secs,
+            warmup_ms,
+            mem_limit,
+            total_bytes,
+            &ratio_label,
+            32, // prefetch distance in pages
+        );
+    }
+
+    // --- Strategy E: batch prefetch — WILLNEED a batch, then read them all ---
+    for &batch_size in &[8, 32, 128] {
+        let label = format!("rand+batch{batch_size}");
+        run_batch_prefetch_read(
+            &label,
+            1,
+            &page_addrs,
+            measure_secs,
+            warmup_ms,
+            mem_limit,
+            total_bytes,
+            &ratio_label,
+            batch_size,
+        );
+    }
+
+    // --- Strategy F: MADV_RANDOM + prefetch (best of both: no useless readahead + explicit prefetch) ---
+    #[cfg(target_os = "linux")]
+    {
+        madvise_all(libc::MADV_RANDOM);
+        for &threads in THREAD_COUNTS {
+            run_prefetch_read(
+                "rand+RANDOM+pf",
+                threads,
+                &page_addrs,
+                measure_secs,
+                warmup_ms,
+                mem_limit,
+                total_bytes,
+                &ratio_label,
+                32,
+            );
+        }
+        madvise_all(libc::MADV_NORMAL);
+    }
+
+    // Phase 3: Dealloc half, realloc+touch (single thread, just one data point).
+    let half = regions.len() / 2;
+    for (_ptr, _cap, handle) in regions.drain(..half) {
+        lgalloc::deallocate(handle);
+    }
+
+    {
+        let running = Arc::new(AtomicBool::new(true));
+        let shared_hist = Arc::new(SharedHistogram::new());
+
+        let r2 = Arc::clone(&running);
+        let sh2 = Arc::clone(&shared_hist);
+        let handle = std::thread::spawn(move || {
+            let mut hist = SharedHistogram::recorder();
+            while r2.load(Ordering::Relaxed) {
+                let start = Instant::now();
+                let (ptr, cap, h) = lgalloc::allocate::<u8>(REGION_SIZE).unwrap();
+                let slice = unsafe { std::slice::from_raw_parts_mut(ptr.as_ptr(), cap) };
+                for i in (0..slice.len()).step_by(4096) {
+                    unsafe { std::ptr::write_volatile(&mut slice[i], 1) };
+                }
+                black_box(slice);
+                lgalloc::deallocate(h);
+                let _ = hist.record(start.elapsed().as_nanos() as u64);
+            }
+            sh2.merge(hist);
+        });
+
+        std::thread::sleep(Duration::from_millis(warmup_ms));
+        shared_hist.reset();
+
+        let start = Instant::now();
+        std::thread::sleep(Duration::from_secs(measure_secs));
+        running.store(false, Ordering::SeqCst);
+        handle.join().unwrap();
+
+        let elapsed = start.elapsed();
+        let hist = shared_hist.combined();
+        print_result(
+            "realloc_touch", 1, mem_limit, total_bytes, &ratio_label, elapsed, &hist,
+        );
+    }
+
+    // Cleanup
+    for (_ptr, _cap, handle) in regions.drain(..) {
+        lgalloc::deallocate(handle);
+    }
+}
+
+fn bench_paging(total_mib: Option<usize>) {
     // Read cgroup memory limit to determine how much RAM we have.
     let mem_limit = read_cgroup_memory_limit().unwrap_or(512 << 20);
-    // Allocate 3x the memory limit to guarantee swap pressure.
-    let total_bytes = mem_limit * 3;
+    let total_bytes = total_mib
+        .map(|m| m << 20)
+        .unwrap_or(mem_limit * 3);
     let num_regions = total_bytes / REGION_SIZE;
 
     println!("=== Paging benchmark ===");
@@ -562,9 +1026,22 @@ fn bench_paging() {
     }
 }
 
-/// Read cgroup v2 memory.max, falling back to cgroup v1.
+/// Read cgroup v2 memory.max for the current process's cgroup, falling back to cgroup v1.
 fn read_cgroup_memory_limit() -> Option<usize> {
-    // cgroup v2
+    // Find our own cgroup path from /proc/self/cgroup
+    let cgroup_path = std::fs::read_to_string("/proc/self/cgroup").ok()?;
+    // cgroup v2: line starts with "0::" followed by the path
+    for line in cgroup_path.lines() {
+        if let Some(path) = line.strip_prefix("0::") {
+            let memory_max = format!("/sys/fs/cgroup{path}/memory.max");
+            if let Ok(content) = std::fs::read_to_string(&memory_max) {
+                if let Ok(limit) = content.trim().parse::<usize>() {
+                    return Some(limit);
+                }
+            }
+        }
+    }
+    // Fallback: fixed path (works if already in the right cgroup)
     if let Ok(content) = std::fs::read_to_string("/sys/fs/cgroup/memory.max") {
         if let Ok(limit) = content.trim().parse::<usize>() {
             return Some(limit);

--- a/examples/disk_usage.rs
+++ b/examples/disk_usage.rs
@@ -45,12 +45,6 @@ fn main() {
 fn print_stats() {
     let stats = lgalloc::lgalloc_stats_with_mapping().unwrap();
 
-    for (size_class, file_stats) in &stats.file {
-        match file_stats {
-            Ok(file_stats) => println!("file_stats {size_class} {file_stats:?}"),
-            Err(e) => eprintln!("Failed to read file stats for size class {size_class}: {e}"),
-        }
-    }
     for (size_class, map_stats) in stats.map.iter().flatten() {
         println!("map_stats {size_class} {map_stats:?}");
     }

--- a/examples/disk_usage.rs
+++ b/examples/disk_usage.rs
@@ -1,4 +1,4 @@
-//! Example that shows the disk usage for lgalloc.
+//! Example that demonstrates lgalloc's anonymous memory allocations with THP hints.
 fn main() {
     let buffer_size = 32 << 20;
 
@@ -7,7 +7,6 @@ fn main() {
     let mut config = lgalloc::LgAlloc::new();
     config.enable();
     config.eager_return(true);
-    config.with_path(std::env::temp_dir());
     lgalloc::lgalloc_set_config(&config);
 
     println!("Allocating {buffers} regions of {buffer_size} size...");
@@ -43,9 +42,15 @@ fn main() {
 }
 
 fn print_stats() {
-    let stats = lgalloc::lgalloc_stats_with_mapping().unwrap();
+    let stats = lgalloc::lgalloc_stats();
 
-    for (size_class, map_stats) in stats.map.iter().flatten() {
-        println!("map_stats {size_class} {map_stats:?}");
+    for (size_class, stats) in &stats.size_class {
+        if stats.areas > 0 {
+            println!(
+                "size_class {size_class}: areas={}, total_bytes={}, free={}, clean={}, global={}, thread={}",
+                stats.areas, stats.area_total_bytes, stats.free_regions, stats.clean_regions,
+                stats.global_regions, stats.thread_regions,
+            );
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,6 +99,38 @@ impl Handle {
         unsafe { self.madvise(libc::MADV_DONTNEED) }
     }
 
+    /// Hint to the kernel that a byte range within this allocation will be needed soon.
+    ///
+    /// Issues `MADV_WILLNEED` to initiate asynchronous page-in for the range
+    /// `[offset, offset + len)`, which is especially useful when pages may reside in
+    /// swap. The kernel begins reading pages in the background; a subsequent access to
+    /// a prefetched page will either find it already resident or wait for a shorter I/O.
+    ///
+    /// `offset` and `len` do not need to be page-aligned — the kernel rounds to page
+    /// boundaries internally.
+    ///
+    /// This is a performance hint and never affects correctness. The kernel may ignore
+    /// it under memory pressure. Calling it on already-resident pages is a no-op.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AllocError::OutOfMemory`] if `offset + len` exceeds the allocation length.
+    pub fn prefetch(&self, offset: usize, len: usize) -> Result<(), AllocError> {
+        if len == 0 || self.is_dangling() {
+            return Ok(());
+        }
+        if offset.saturating_add(len) > self.len {
+            return Err(AllocError::OutOfMemory);
+        }
+        // SAFETY: MADV_WILLNEED is a hint that never modifies memory contents.
+        // The pointer arithmetic is in-bounds per the check above.
+        unsafe {
+            let ptr = self.as_non_null().as_ptr().add(offset);
+            libc::madvise(ptr.cast(), len, libc::MADV_WILLNEED);
+        }
+        Ok(())
+    }
+
     /// Call `madvise` on the memory region. Unsafe because `advice` is passed verbatim.
     unsafe fn madvise(&self, advice: libc::c_int) -> std::io::Result<()> {
         // SAFETY: Calling into `madvise`:
@@ -685,6 +717,7 @@ pub fn deallocate(handle: Handle) {
     }
     thread_context(|s| s.deallocate(handle));
 }
+
 
 /// A background worker that performs periodic tasks.
 struct BackgroundWorker {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,15 +1,18 @@
-//! A size-classed file-backed large object allocator.
+//! A size-classed large object allocator backed by anonymous mappings.
 //!
 //! This library contains types to allocate memory outside the heap,
 //! supporting power-of-two object sizes. Each size class has its own
 //! memory pool.
+//!
+//! Allocations use `MAP_ANONYMOUS` with `MADV_HUGEPAGE` hints to benefit
+//! from transparent huge pages when available.
 //!
 //! # Safety
 //!
 //! This library is very unsafe on account of `unsafe` and interacting directly
 //! with libc, including Linux extension.
 //!
-//! The library relies on memory-mapped files. Users of this file must not fork the process
+//! The library relies on anonymous memory mappings. Users must not fork the process
 //! because otherwise two processes would share the same mappings, causing undefined behavior
 //! because the mutable pointers would not be unique anymore. Unfortunately, there is no way
 //! to tell the memory subsystem that the shared mappings must not be inherited.
@@ -24,7 +27,6 @@ use std::collections::HashMap;
 use std::marker::PhantomData;
 use std::mem::{take, ManuallyDrop};
 use std::ops::Range;
-use std::path::PathBuf;
 use std::ptr::NonNull;
 use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 use std::sync::mpsc::{Receiver, RecvTimeoutError, Sender};
@@ -33,7 +35,6 @@ use std::thread::{JoinHandle, ThreadId};
 use std::time::{Duration, Instant};
 
 use crossbeam_deque::{Injector, Steal, Stealer, Worker};
-use numa_maps::NumaMap;
 use thiserror::Error;
 
 mod readme {
@@ -83,13 +84,16 @@ impl Handle {
         self.ptr
     }
 
-    /// Indicate that the memory is not in use and that the OS can recycle it.
+    /// Indicate that the memory is not in use and that the OS can lazily recycle it.
+    ///
+    /// Uses `MADV_FREE` on Linux (lazy reclaim, avoids immediate page zeroing) and
+    /// `MADV_DONTNEED` elsewhere.
     fn clear(&mut self) -> std::io::Result<()> {
-        // SAFETY: `MADV_DONTNEED_STRATEGY` guaranteed to be a valid argument.
-        unsafe { self.madvise(MADV_DONTNEED_STRATEGY) }
+        // SAFETY: `MADV_CLEAR_STRATEGY` guaranteed to be a valid argument.
+        unsafe { self.madvise(MADV_CLEAR_STRATEGY) }
     }
 
-    /// Indicate that the memory is not in use and that the OS can recycle it.
+    /// Indicate that the memory is not in use and that the OS should immediately recycle it.
     fn fast_clear(&mut self) -> std::io::Result<()> {
         // SAFETY: `libc::MADV_DONTNEED` documented to be a valid argument.
         unsafe { self.madvise(libc::MADV_DONTNEED) }
@@ -100,7 +104,6 @@ impl Handle {
         // SAFETY: Calling into `madvise`:
         // * The ptr is page-aligned by construction.
         // * The ptr + length is page-aligned by construction (not required but surprising otherwise)
-        // * Mapped shared and writable (for MADV_REMOVE),
         // * Pages not locked.
         // * The caller is responsible for passing a valid `advice` parameter.
         let ptr = self.as_non_null().as_ptr().cast();
@@ -113,21 +116,21 @@ impl Handle {
     }
 }
 
-/// Initial file size
+/// Initial area size
 const INITIAL_SIZE: usize = 32 << 20;
 
 /// Range of valid size classes.
 pub const VALID_SIZE_CLASS: Range<usize> = 20..37;
 
-/// Strategy to indicate that the OS can reclaim pages
-// TODO: On Linux, we want to use MADV_REMOVE, but that's only supported
-// on file systems that supports FALLOC_FL_PUNCH_HOLE. We should check
-// the return value and retry EOPNOTSUPP with MADV_DONTNEED.
+/// Strategy for background worker clear: `MADV_FREE` on Linux (lazy reclaim), `MADV_DONTNEED` elsewhere.
 #[cfg(target_os = "linux")]
-const MADV_DONTNEED_STRATEGY: libc::c_int = libc::MADV_REMOVE;
+const MADV_CLEAR_STRATEGY: libc::c_int = libc::MADV_FREE;
 
 #[cfg(not(target_os = "linux"))]
-const MADV_DONTNEED_STRATEGY: libc::c_int = libc::MADV_DONTNEED;
+const MADV_CLEAR_STRATEGY: libc::c_int = libc::MADV_DONTNEED;
+
+/// Whether we have already warned about `MADV_HUGEPAGE` failure.
+static MADV_HUGEPAGE_WARNED: AtomicBool = AtomicBool::new(false);
 
 type PhantomUnsyncUnsend<T> = PhantomData<*mut T>;
 
@@ -223,11 +226,11 @@ static LGALLOC_ENABLED: AtomicBool = AtomicBool::new(false);
 /// Enable eager returning of memory. Off by default.
 static LGALLOC_EAGER_RETURN: AtomicBool = AtomicBool::new(false);
 
-/// Dampener in the file growth rate. 0 corresponds to doubling and in general `n` to `1+1/(n+1)`.
+/// Dampener in the area growth rate. 0 corresponds to doubling and in general `n` to `1+1/(n+1)`.
 ///
-/// Setting this to 0 results in creating files with doubling capacity.
-/// Larger numbers result in more conservative approaches that create more files.
-static LGALLOC_FILE_GROWTH_DAMPENER: AtomicUsize = AtomicUsize::new(0);
+/// Setting this to 0 results in creating areas with doubling capacity.
+/// Larger numbers result in more conservative approaches that create more areas.
+static LGALLOC_GROWTH_DAMPENER: AtomicUsize = AtomicUsize::new(0);
 
 /// The size of allocations to retain locally, per thread and size class.
 static LOCAL_BUFFER_BYTES: AtomicUsize = AtomicUsize::new(32 << 20);
@@ -237,8 +240,6 @@ struct GlobalStealer {
     /// State for each size class. An entry at position `x` handle size class `x`, which is areas
     /// of size `1<<x`.
     size_classes: Vec<SizeClassState>,
-    /// Path to store files
-    path: RwLock<Option<PathBuf>>,
     /// Shared token to access background thread.
     background_sender: Mutex<Option<(JoinHandle<()>, Sender<BackgroundWorkerConfig>)>>,
 }
@@ -246,7 +247,7 @@ struct GlobalStealer {
 /// Per-size-class state
 #[derive(Default)]
 struct SizeClassState {
-    /// Handle to memory-mapped regions.
+    /// Handle to anonymous memory-mapped regions.
     ///
     /// We must never dereference the memory-mapped regions stored here.
     areas: RwLock<Vec<ManuallyDrop<(usize, usize)>>>,
@@ -286,7 +287,6 @@ impl GlobalStealer {
 
         Self {
             size_classes,
-            path: RwLock::default(),
             background_sender: Mutex::default(),
         }
     }
@@ -294,6 +294,17 @@ impl GlobalStealer {
 
 impl Drop for GlobalStealer {
     fn drop(&mut self) {
+        // Unmap all areas to return virtual address space.
+        for size_class_state in &mut self.size_classes {
+            let mut areas = size_class_state.areas.write().expect("lock poisoned");
+            for area in areas.drain(..) {
+                let (addr, len) = ManuallyDrop::into_inner(area);
+                // SAFETY: `addr` and `len` were returned by `mmap` during `try_refill_and_get`.
+                unsafe {
+                    libc::munmap(addr as *mut libc::c_void, len);
+                }
+            }
+        }
         take(&mut self.size_classes);
     }
 }
@@ -485,8 +496,8 @@ impl LocalSizeClass {
 
         let last_capacity =
             stash.iter().last().map_or(0, |mmap| mmap.1) / self.size_class.byte_size();
-        let growth_dampener = LGALLOC_FILE_GROWTH_DAMPENER.load(Ordering::Relaxed);
-        // We would like to grow the file capacity by a factor of `1+1/(growth_dampener+1)`,
+        let growth_dampener = LGALLOC_GROWTH_DAMPENER.load(Ordering::Relaxed);
+        // We would like to grow the area capacity by a factor of `1+1/(growth_dampener+1)`,
         // but at least by `initial_capacity`.
         let next_capacity = last_capacity
             + std::cmp::max(
@@ -495,29 +506,8 @@ impl LocalSizeClass {
             );
 
         let next_byte_len = next_capacity * self.size_class.byte_size();
-        // let (file, mut mmap) = Self::init_file(next_byte_len)?;
 
-        let mmap = unsafe {
-            libc::mmap(std::ptr::null_mut(), next_byte_len,
-                libc::PROT_READ | libc::PROT_WRITE,
-                libc::MAP_PRIVATE | libc::MAP_ANONYMOUS,
-                -1,
-                0)
-        };
-        if mmap == libc::MAP_FAILED {
-            println!("mmap failed, length {next_byte_len}");
-            println!("mmap failed: {}", std::io::Error::last_os_error());
-            return Err(std::io::Error::last_os_error().into());
-        }
-        unsafe {
-            let ret = libc::madvise(mmap, next_byte_len, libc::MADV_HUGEPAGE);
-            if ret == -1 {
-                return Err(std::io::Error::last_os_error().into());
-            }
-        }
-        let slice = unsafe {
-            std::slice::from_raw_parts_mut(mmap.cast::<u8>(), next_byte_len)
-        };
+        let (mmap_ptr, slice) = mmap_anonymous(next_byte_len)?;
 
         self.size_class_state
             .total_bytes
@@ -542,9 +532,47 @@ impl LocalSizeClass {
                 .push(Handle::new(ptr, self.size_class.byte_size()));
         }
 
-        stash.push(ManuallyDrop::new((mmap.addr(), next_byte_len)));
+        stash.push(ManuallyDrop::new((mmap_ptr, next_byte_len)));
         Ok(mem)
     }
+}
+
+/// Create an anonymous memory mapping with huge page hints.
+///
+/// Returns a tuple of `(address, mutable slice)` on success.
+fn mmap_anonymous(len: usize) -> Result<(usize, &'static mut [u8]), AllocError> {
+    // SAFETY: Creating an anonymous private mapping with no file descriptor.
+    let ptr = unsafe {
+        libc::mmap(
+            std::ptr::null_mut(),
+            len,
+            libc::PROT_READ | libc::PROT_WRITE,
+            libc::MAP_PRIVATE | libc::MAP_ANONYMOUS,
+            -1,
+            0,
+        )
+    };
+    if ptr == libc::MAP_FAILED {
+        return Err(std::io::Error::last_os_error().into());
+    }
+
+    // Hint to the kernel to use transparent huge pages. This is a performance hint,
+    // not a correctness requirement — THP may be disabled system-wide.
+    #[cfg(target_os = "linux")]
+    {
+        // SAFETY: `ptr` is a valid mapping returned by `mmap` above.
+        let ret = unsafe { libc::madvise(ptr, len, libc::MADV_HUGEPAGE) };
+        if ret == -1 && !MADV_HUGEPAGE_WARNED.swap(true, Ordering::Relaxed) {
+            eprintln!(
+                "lgalloc: MADV_HUGEPAGE failed: {}. Transparent huge pages may be disabled.",
+                std::io::Error::last_os_error()
+            );
+        }
+    }
+
+    // SAFETY: `ptr` is a valid mapping of `len` bytes.
+    let slice = unsafe { std::slice::from_raw_parts_mut(ptr.cast::<u8>(), len) };
+    Ok((ptr as usize, slice))
 }
 
 impl Drop for LocalSizeClass {
@@ -746,10 +774,7 @@ impl BackgroundWorker {
 /// Set or update the configuration for lgalloc.
 ///
 /// The function accepts a configuration, which is then applied on lgalloc. It allows clients to
-/// change the path where area files reside, and change the configuration of the background task.
-///
-/// Updating the area path only applies to new allocations, existing allocations are not moved to
-/// the new path.
+/// change the configuration of the background task.
 ///
 /// Updating the background thread configuration eventually applies the new configuration on the
 /// running thread, or starts the background worker.
@@ -768,12 +793,8 @@ pub fn lgalloc_set_config(config: &LgAlloc) {
         LGALLOC_EAGER_RETURN.store(*eager_return, Ordering::Relaxed);
     }
 
-    if let Some(path) = &config.path {
-        *stealer.path.write().expect("lock poisoned") = Some(path.clone());
-    }
-
-    if let Some(file_growth_dampener) = &config.file_growth_dampener {
-        LGALLOC_FILE_GROWTH_DAMPENER.store(*file_growth_dampener, Ordering::Relaxed);
+    if let Some(growth_dampener) = &config.growth_dampener {
+        LGALLOC_GROWTH_DAMPENER.store(*growth_dampener, Ordering::Relaxed);
     }
 
     if let Some(local_buffer_bytes) = &config.local_buffer_bytes {
@@ -818,14 +839,12 @@ pub struct BackgroundWorkerConfig {
 pub struct LgAlloc {
     /// Whether the allocator is enabled or not.
     pub enabled: Option<bool>,
-    /// Path where files reside.
-    pub path: Option<PathBuf>,
     /// Configuration of the background worker.
     pub background_config: Option<BackgroundWorkerConfig>,
     /// Whether to return physical memory on deallocate
     pub eager_return: Option<bool>,
-    /// Dampener in the file growth rate. 0 corresponds to doubling and in general `n` to `1+1/(n+1)`.
-    pub file_growth_dampener: Option<usize>,
+    /// Dampener in the area growth rate. 0 corresponds to doubling and in general `n` to `1+1/(n+1)`.
+    pub growth_dampener: Option<usize>,
     /// Size of the per-thread per-size class cache, in bytes.
     pub local_buffer_bytes: Option<usize>,
 }
@@ -855,21 +874,15 @@ impl LgAlloc {
         self
     }
 
-    /// Set the area file path.
-    pub fn with_path(&mut self, path: PathBuf) -> &mut Self {
-        self.path = Some(path);
-        self
-    }
-
     /// Enable eager memory reclamation.
     pub fn eager_return(&mut self, eager_return: bool) -> &mut Self {
         self.eager_return = Some(eager_return);
         self
     }
 
-    /// Set the file growth dampener.
-    pub fn file_growth_dampener(&mut self, file_growth_dapener: usize) -> &mut Self {
-        self.file_growth_dampener = Some(file_growth_dapener);
+    /// Set the area growth dampener.
+    pub fn growth_dampener(&mut self, growth_dampener: usize) -> &mut Self {
+        self.growth_dampener = Some(growth_dampener);
         self
     }
 
@@ -883,35 +896,28 @@ impl LgAlloc {
 /// Determine global statistics per size class.
 ///
 /// This function is supposed to be relatively fast. It causes some syscalls, but they
-/// should be cheap (stat on a file descriptor).
+/// should be cheap.
 ///
-/// Note that this function take a read lock on various structures. It calls `fstat` while
-/// holding a read lock on portions of the global state, which can block refills until the
-/// function returns.
+/// Note that this function takes a read lock on various structures, which can block refills
+/// until the function returns.
 ///
 /// # Panics
 ///
 /// Panics if the internal state of lgalloc is corrupted.
 pub fn lgalloc_stats() -> LgAllocStats {
-    LgAllocStats::read(None)
-}
+    let global = GlobalStealer::get_static();
 
-/// Determine global statistics per size class, and include mapping information.
-///
-/// This function can be very slow as it needs to read the `numa_maps` file. Depending
-/// on the heap size of the program, this can take seconds to minutes, so call this
-/// function with care.
-///
-/// Note that this function take a read lock on various structures. In addition to the locks
-/// described on [`lgalloc_stats`], this function reads the `/proc/self/numa_maps` file without
-/// holding any locks, but the kernel might block other memory operations while reading this file.
-///
-/// # Panics
-///
-/// Panics if the internal state of lgalloc is corrupted.
-pub fn lgalloc_stats_with_mapping() -> std::io::Result<LgAllocStats> {
-    let mut numa_map = NumaMap::from_file("/proc/self/numa_maps")?;
-    Ok(LgAllocStats::read(Some(&mut numa_map)))
+    let mut size_class_stats = Vec::with_capacity(VALID_SIZE_CLASS.len());
+    for (index, state) in global.size_classes.iter().enumerate() {
+        let size_class = SizeClass::from_index(index);
+        let size_class_bytes = size_class.byte_size();
+
+        size_class_stats.push((size_class_bytes, SizeClassStats::from(state)));
+    }
+
+    LgAllocStats {
+        size_class: size_class_stats,
+    }
 }
 
 /// Statistics about lgalloc's internal behavior.
@@ -919,40 +925,6 @@ pub fn lgalloc_stats_with_mapping() -> std::io::Result<LgAllocStats> {
 pub struct LgAllocStats {
     /// Per size-class statistics.
     pub size_class: Vec<(usize, SizeClassStats)>,
-    /// Per size-class and map statistics. Each entry identifies the
-    /// size class it describes, and there can be multiple entries for each size class.
-    pub map: Option<Vec<(usize, MapStats)>>,
-}
-
-impl LgAllocStats {
-    /// Read lgalloc statistics.
-    ///
-    /// Supply a `numa_map` to obtain mapping stats.
-    fn read(mut numa_map: Option<&mut NumaMap>) -> Self {
-        let global = GlobalStealer::get_static();
-
-        if let Some(numa_map) = numa_map.as_mut() {
-            // Normalize numa_maps, and sort by address.
-            for entry in &mut numa_map.ranges {
-                entry.normalize();
-            }
-            numa_map.ranges.sort();
-        }
-
-        let mut size_class_stats = Vec::with_capacity(VALID_SIZE_CLASS.len());
-        let map_stats = Vec::default();
-        for (index, state) in global.size_classes.iter().enumerate() {
-            let size_class = SizeClass::from_index(index);
-            let size_class_bytes = size_class.byte_size();
-
-            size_class_stats.push((size_class_bytes, SizeClassStats::from(state)));
-        }
-
-        Self {
-            size_class: size_class_stats,
-            map: numa_map.map(|_| map_stats),
-        }
-    }
 }
 
 /// Statistics per size class.
@@ -1032,238 +1004,5 @@ impl From<&SizeClassState> for SizeClassStats {
             clear_eager_total,
             clear_slow_total,
         }
-    }
-}
-
-/// Statistics per size class and mapping.
-#[derive(Debug)]
-pub struct MapStats {
-    /// Number of mapped bytes, if different from `dirty`. Consult `man 7 numa` for details.
-    pub mapped: usize,
-    /// Number of active bytes. Consult `man 7 numa` for details.
-    pub active: usize,
-    /// Number of dirty bytes. Consult `man 7 numa` for details.
-    pub dirty: usize,
-}
-
-#[cfg(test)]
-mod test {
-    use std::mem::{ManuallyDrop, MaybeUninit};
-    use std::ptr::NonNull;
-    use std::sync::atomic::{AtomicBool, Ordering};
-    use std::sync::Arc;
-    use std::time::Duration;
-
-    use serial_test::serial;
-
-    use super::*;
-
-    fn initialize() {
-        lgalloc_set_config(
-            LgAlloc::new()
-                .enable()
-                .with_background_config(BackgroundWorkerConfig {
-                    interval: Duration::from_secs(1),
-                    clear_bytes: 4 << 20,
-                })
-                .with_path(std::env::temp_dir())
-                .file_growth_dampener(1),
-        );
-    }
-
-    struct Wrapper<T> {
-        handle: MaybeUninit<Handle>,
-        ptr: NonNull<MaybeUninit<T>>,
-        cap: usize,
-    }
-
-    unsafe impl<T: Send> Send for Wrapper<T> {}
-    unsafe impl<T: Sync> Sync for Wrapper<T> {}
-
-    impl<T> Wrapper<T> {
-        fn allocate(capacity: usize) -> Result<Self, AllocError> {
-            let (ptr, cap, handle) = allocate(capacity)?;
-            assert!(cap > 0);
-            let handle = MaybeUninit::new(handle);
-            Ok(Self { ptr, cap, handle })
-        }
-
-        fn as_slice(&mut self) -> &mut [MaybeUninit<T>] {
-            unsafe { std::slice::from_raw_parts_mut(self.ptr.as_ptr(), self.cap) }
-        }
-    }
-
-    impl<T> Drop for Wrapper<T> {
-        fn drop(&mut self) {
-            unsafe { deallocate(self.handle.assume_init_read()) };
-        }
-    }
-
-    #[test]
-    #[serial]
-    fn test_readme() -> Result<(), AllocError> {
-        initialize();
-
-        // Allocate memory
-        let (ptr, cap, handle) = allocate::<u8>(2 << 20)?;
-        // SAFETY: `allocate` returns a valid memory region and errors otherwise.
-        let mut vec = ManuallyDrop::new(unsafe { Vec::from_raw_parts(ptr.as_ptr(), 0, cap) });
-
-        // Write into region, make sure not to reallocate vector.
-        vec.extend_from_slice(&[1, 2, 3, 4]);
-
-        // We can read from the vector.
-        assert_eq!(&*vec, &[1, 2, 3, 4]);
-
-        // Deallocate after use
-        deallocate(handle);
-        Ok(())
-    }
-
-    #[test]
-    #[serial]
-    fn test_1() -> Result<(), AllocError> {
-        initialize();
-        <Wrapper<u8>>::allocate(4 << 20)?.as_slice()[0] = MaybeUninit::new(1);
-        Ok(())
-    }
-
-    #[test]
-    #[serial]
-    fn test_3() -> Result<(), AllocError> {
-        initialize();
-        let until = Arc::new(AtomicBool::new(true));
-
-        let inner = || {
-            let until = Arc::clone(&until);
-            move || {
-                let mut i = 0;
-                let until = &*until;
-                while until.load(Ordering::Relaxed) {
-                    i += 1;
-                    let mut r = <Wrapper<u8>>::allocate(4 << 20).unwrap();
-                    r.as_slice()[0] = MaybeUninit::new(1);
-                }
-                println!("repetitions: {i}");
-            }
-        };
-        let handles = [
-            std::thread::spawn(inner()),
-            std::thread::spawn(inner()),
-            std::thread::spawn(inner()),
-            std::thread::spawn(inner()),
-        ];
-        std::thread::sleep(Duration::from_secs(4));
-        until.store(false, Ordering::Relaxed);
-        for handle in handles {
-            handle.join().unwrap();
-        }
-        // std::thread::sleep(Duration::from_secs(600));
-        Ok(())
-    }
-
-    #[test]
-    #[serial]
-    fn test_4() -> Result<(), AllocError> {
-        initialize();
-        let until = Arc::new(AtomicBool::new(true));
-
-        let inner = || {
-            let until = Arc::clone(&until);
-            move || {
-                let mut i = 0;
-                let until = &*until;
-                let batch = 64;
-                let mut buffer = Vec::with_capacity(batch);
-                while until.load(Ordering::Relaxed) {
-                    i += 64;
-                    buffer.extend((0..batch).map(|_| {
-                        let mut r = <Wrapper<u8>>::allocate(2 << 20).unwrap();
-                        r.as_slice()[0] = MaybeUninit::new(1);
-                        r
-                    }));
-                    buffer.clear();
-                }
-                println!("repetitions vec: {i}");
-            }
-        };
-        let handles = [
-            std::thread::spawn(inner()),
-            std::thread::spawn(inner()),
-            std::thread::spawn(inner()),
-            std::thread::spawn(inner()),
-        ];
-        std::thread::sleep(Duration::from_secs(4));
-        until.store(false, Ordering::Relaxed);
-        for handle in handles {
-            handle.join().unwrap();
-        }
-        std::thread::sleep(Duration::from_secs(1));
-        let stats = lgalloc_stats();
-        for size_class in &stats.size_class {
-            println!("size_class {:?}", size_class);
-        }
-        Ok(())
-    }
-
-    #[test]
-    #[serial]
-    fn leak() -> Result<(), AllocError> {
-        lgalloc_set_config(&LgAlloc {
-            enabled: Some(true),
-            path: Some(std::env::temp_dir()),
-            ..Default::default()
-        });
-        let r = <Wrapper<u8>>::allocate(1 << 20)?;
-
-        let thread = std::thread::spawn(move || drop(r));
-
-        thread.join().unwrap();
-        Ok(())
-    }
-
-    #[test]
-    #[serial]
-    fn test_zst() -> Result<(), AllocError> {
-        initialize();
-        <Wrapper<()>>::allocate(10)?;
-        Ok(())
-    }
-
-    #[test]
-    #[serial]
-    fn test_zero_capacity_zst() -> Result<(), AllocError> {
-        initialize();
-        <Wrapper<()>>::allocate(0)?;
-        Ok(())
-    }
-
-    #[test]
-    #[serial]
-    fn test_zero_capacity_nonzst() -> Result<(), AllocError> {
-        initialize();
-        <Wrapper<()>>::allocate(0)?;
-        Ok(())
-    }
-
-    #[test]
-    #[serial]
-    fn test_stats() -> Result<(), AllocError> {
-        initialize();
-        let (_ptr, _cap, handle) = allocate::<usize>(1024)?;
-        deallocate(handle);
-
-        let stats = lgalloc_stats();
-
-        assert!(!stats.size_class.is_empty());
-
-        Ok(())
-    }
-
-    #[test]
-    #[serial]
-    fn test_disable() {
-        lgalloc_set_config(&*LgAlloc::new().disable());
-        assert!(matches!(allocate::<u8>(1024), Err(AllocError::Disabled)));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -162,6 +162,7 @@ const MADV_CLEAR_STRATEGY: libc::c_int = libc::MADV_FREE;
 const MADV_CLEAR_STRATEGY: libc::c_int = libc::MADV_DONTNEED;
 
 /// Whether we have already warned about `MADV_HUGEPAGE` failure.
+#[cfg(target_os = "linux")]
 static MADV_HUGEPAGE_WARNED: AtomicBool = AtomicBool::new(false);
 
 type PhantomUnsyncUnsend<T> = PhantomData<*mut T>;
@@ -717,7 +718,6 @@ pub fn deallocate(handle: Handle) {
     }
     thread_context(|s| s.deallocate(handle));
 }
-
 
 /// A background worker that performs periodic tasks.
 struct BackgroundWorker {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,34 +99,55 @@ impl Handle {
         unsafe { self.madvise(libc::MADV_DONTNEED) }
     }
 
-    /// Hint to the kernel that a byte range within this allocation will be needed soon.
+    /// Hint to the kernel that a range of elements will be needed soon.
     ///
-    /// Issues `MADV_WILLNEED` to initiate asynchronous page-in for the range
-    /// `[offset, offset + len)`, which is especially useful when pages may reside in
-    /// swap. The kernel begins reading pages in the background; a subsequent access to
-    /// a prefetched page will either find it already resident or wait for a shorter I/O.
+    /// Issues `MADV_WILLNEED` to initiate asynchronous page-in for elements
+    /// `range.start..range.end` of type `T`, which is especially useful when pages may
+    /// reside in swap. The kernel begins reading pages in the background; a subsequent
+    /// access to a prefetched page will either find it already resident or wait for a
+    /// shorter I/O.
     ///
-    /// `offset` and `len` do not need to be page-aligned — the kernel rounds to page
-    /// boundaries internally.
+    /// `T` should match the element type used with [`allocate`]. Use `u8` for
+    /// byte-granularity prefetch.
+    ///
+    /// The resulting byte range does not need to be page-aligned — the kernel rounds
+    /// to page boundaries internally.
     ///
     /// This is a performance hint and never affects correctness. The kernel may ignore
     /// it under memory pressure. Calling it on already-resident pages is a no-op.
     ///
     /// # Errors
     ///
-    /// Returns [`AllocError::OutOfMemory`] if `offset + len` exceeds the allocation length.
-    pub fn prefetch(&self, offset: usize, len: usize) -> Result<(), AllocError> {
-        if len == 0 || self.is_dangling() {
+    /// Returns [`PrefetchError::OutOfBounds`] if the byte range exceeds the allocation length.
+    pub fn prefetch<T>(&self, range: Range<usize>) -> Result<(), PrefetchError> {
+        let elem_size = std::mem::size_of::<T>();
+        let byte_offset = range.start.checked_mul(elem_size);
+        let byte_len = (range.end - range.start).checked_mul(elem_size);
+        let (byte_offset, byte_len) = match (byte_offset, byte_len) {
+            (Some(o), Some(l)) => (o, l),
+            _ => {
+                return Err(PrefetchError::OutOfBounds {
+                    byte_offset: range.start.saturating_mul(elem_size),
+                    byte_len: range.len().saturating_mul(elem_size),
+                    allocation_len: self.len,
+                });
+            }
+        };
+        if byte_len == 0 || self.is_dangling() {
             return Ok(());
         }
-        if offset.saturating_add(len) > self.len {
-            return Err(AllocError::OutOfMemory);
+        if byte_offset.saturating_add(byte_len) > self.len {
+            return Err(PrefetchError::OutOfBounds {
+                byte_offset,
+                byte_len,
+                allocation_len: self.len,
+            });
         }
         // SAFETY: MADV_WILLNEED is a hint that never modifies memory contents.
         // The pointer arithmetic is in-bounds per the check above.
         unsafe {
-            let ptr = self.as_non_null().as_ptr().add(offset);
-            libc::madvise(ptr.cast(), len, libc::MADV_WILLNEED);
+            let ptr = self.as_non_null().as_ptr().add(byte_offset);
+            libc::madvise(ptr.cast(), byte_len, libc::MADV_WILLNEED);
         }
         Ok(())
     }
@@ -152,7 +173,7 @@ impl Handle {
 const INITIAL_SIZE: usize = 32 << 20;
 
 /// Range of valid size classes.
-pub const VALID_SIZE_CLASS: Range<usize> = 20..37;
+pub const VALID_SIZE_CLASS: Range<usize> = 21..37;
 
 /// Strategy for background worker clear: `MADV_FREE` on Linux (lazy reclaim), `MADV_DONTNEED` elsewhere.
 #[cfg(target_os = "linux")]
@@ -185,6 +206,21 @@ pub enum AllocError {
     /// Failed to allocate memory that suits alignment properties.
     #[error("Memory unsuitable for requested alignment")]
     UnalignedMemory,
+}
+
+/// Errors from [`Handle::prefetch`].
+#[derive(Error, Debug)]
+pub enum PrefetchError {
+    /// The requested byte range exceeds the allocation.
+    #[error("prefetch byte range [{byte_offset}..{end}) exceeds allocation length {allocation_len}", end = byte_offset + byte_len)]
+    OutOfBounds {
+        /// Byte offset of the requested range.
+        byte_offset: usize,
+        /// Byte length of the requested range.
+        byte_len: usize,
+        /// Total byte length of the allocation.
+        allocation_len: usize,
+    },
 }
 
 impl AllocError {
@@ -270,7 +306,7 @@ static LOCAL_BUFFER_BYTES: AtomicUsize = AtomicUsize::new(32 << 20);
 
 /// Type maintaining the global state for each size class.
 struct GlobalStealer {
-    /// State for each size class. An entry at position `x` handle size class `x`, which is areas
+    /// State for each size class. An entry at position `x` handles size class `x`, which is areas
     /// of size `1<<x`.
     size_classes: Vec<SizeClassState>,
     /// Shared token to access background thread.
@@ -441,7 +477,7 @@ impl LocalSizeClass {
     /// Get a memory area. Tries to get a region from the local cache, before obtaining data from
     /// the global state. As a last option, obtains memory from other workers.
     ///
-    /// Returns [`AllcError::OutOfMemory`] if all pools are empty.
+    /// Returns [`AllocError::OutOfMemory`] if all pools are empty.
     #[inline]
     fn get(&self) -> Result<Handle, AllocError> {
         self.worker
@@ -555,7 +591,7 @@ impl LocalSizeClass {
             .map(|chunk| NonNull::new(chunk.as_mut_ptr()).expect("non-null"));
 
         // Capture first region to return immediately.
-        let ptr = chunks.next().expect("At least once chunk allocated.");
+        let ptr = chunks.next().expect("At least one chunk allocated.");
         let mem = Handle::new(ptr, self.size_class.byte_size());
 
         // Stash remaining in the injector.
@@ -928,8 +964,8 @@ impl LgAlloc {
 
 /// Determine global statistics per size class.
 ///
-/// This function is supposed to be relatively fast. It causes some syscalls, but they
-/// should be cheap.
+/// This function is relatively fast. It reads atomic counters and lock-free queue lengths
+/// without issuing syscalls.
 ///
 /// Note that this function takes a read lock on various structures, which can block refills
 /// until the function returns.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,11 +21,9 @@
 
 use std::cell::RefCell;
 use std::collections::HashMap;
-use std::fs::File;
 use std::marker::PhantomData;
-use std::mem::{take, ManuallyDrop, MaybeUninit};
-use std::ops::{Deref, Range};
-use std::os::fd::{AsFd, AsRawFd};
+use std::mem::{take, ManuallyDrop};
+use std::ops::Range;
 use std::path::PathBuf;
 use std::ptr::NonNull;
 use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
@@ -35,7 +33,6 @@ use std::thread::{JoinHandle, ThreadId};
 use std::time::{Duration, Instant};
 
 use crossbeam_deque::{Injector, Steal, Stealer, Worker};
-use memmap2::MmapMut;
 use numa_maps::NumaMap;
 use thiserror::Error;
 
@@ -503,12 +500,20 @@ impl LocalSizeClass {
         let mmap = unsafe {
             libc::mmap(std::ptr::null_mut(), next_byte_len,
                 libc::PROT_READ | libc::PROT_WRITE,
-                libc::MAP_ANONYMOUS | libc::MAP_HUGETLB,
-                0,
+                libc::MAP_PRIVATE | libc::MAP_ANONYMOUS,
+                -1,
                 0)
         };
         if mmap == libc::MAP_FAILED {
+            println!("mmap failed, length {next_byte_len}");
+            println!("mmap failed: {}", std::io::Error::last_os_error());
             return Err(std::io::Error::last_os_error().into());
+        }
+        unsafe {
+            let ret = libc::madvise(mmap, next_byte_len, libc::MADV_HUGEPAGE);
+            if ret == -1 {
+                return Err(std::io::Error::last_os_error().into());
+            }
         }
         let slice = unsafe {
             std::slice::from_raw_parts_mut(mmap.cast::<u8>(), next_byte_len)
@@ -539,35 +544,6 @@ impl LocalSizeClass {
 
         stash.push(ManuallyDrop::new((mmap.addr(), next_byte_len)));
         Ok(mem)
-    }
-
-    /// Allocate and map a file of size `byte_len`. Returns an handle, or error if the allocation
-    /// fails.
-    fn init_file(byte_len: usize) -> Result<(File, MmapMut), AllocError> {
-        let file = {
-            let path = GlobalStealer::get_static()
-                .path
-                .read()
-                .expect("lock poisoned");
-            let Some(path) = &*path else {
-                return Err(AllocError::Io(std::io::Error::from(
-                    std::io::ErrorKind::NotFound,
-                )));
-            };
-            tempfile::tempfile_in(path)?
-        };
-        let fd = file.as_fd().as_raw_fd();
-        let length = libc::off_t::try_from(byte_len).expect("Must fit");
-        // SAFETY: Calling ftruncate on the file, which we just created.
-        let ret = unsafe { libc::ftruncate(fd, length) };
-        if ret != 0 {
-            // file goes out of scope here, so no need for further cleanup.
-            return Err(std::io::Error::last_os_error().into());
-        }
-        // SAFETY: We only map `file` once, and never share it with other processes.
-        let mmap = unsafe { memmap2::MmapOptions::new().map_mut(&file)? };
-        assert_eq!(mmap.len(), byte_len);
-        Ok((file, mmap))
     }
 }
 
@@ -943,9 +919,6 @@ pub fn lgalloc_stats_with_mapping() -> std::io::Result<LgAllocStats> {
 pub struct LgAllocStats {
     /// Per size-class statistics.
     pub size_class: Vec<(usize, SizeClassStats)>,
-    /// Per size-class and backing file statistics. Each entry identifies the
-    /// size class it describes, and there can be multiple entries for each size class.
-    pub file: Vec<(usize, std::io::Result<FileStats>)>,
     /// Per size-class and map statistics. Each entry identifies the
     /// size class it describes, and there can be multiple entries for each size class.
     pub map: Option<Vec<(usize, MapStats)>>,
@@ -967,26 +940,16 @@ impl LgAllocStats {
         }
 
         let mut size_class_stats = Vec::with_capacity(VALID_SIZE_CLASS.len());
-        let mut file_stats = Vec::default();
-        let mut map_stats = Vec::default();
+        let map_stats = Vec::default();
         for (index, state) in global.size_classes.iter().enumerate() {
             let size_class = SizeClass::from_index(index);
             let size_class_bytes = size_class.byte_size();
 
             size_class_stats.push((size_class_bytes, SizeClassStats::from(state)));
-
-            let areas = state.areas.read().expect("lock poisoned");
-            for (file, mmap) in areas.iter().map(Deref::deref) {
-                file_stats.push((size_class_bytes, FileStats::extract_from(file)));
-                if let Some(numa_map) = numa_map.as_deref() {
-                    map_stats.push((size_class_bytes, MapStats::extract_from(mmap, numa_map)));
-                }
-            }
         }
 
         Self {
             size_class: size_class_stats,
-            file: file_stats,
             map: numa_map.map(|_| map_stats),
         }
     }
@@ -1072,38 +1035,6 @@ impl From<&SizeClassState> for SizeClassStats {
     }
 }
 
-/// Statistics per size class and backing file.
-#[derive(Debug)]
-pub struct FileStats {
-    /// The size of the file in bytes.
-    pub file_size: usize,
-    /// Size of the file on disk in bytes.
-    pub allocated_size: usize,
-}
-
-impl FileStats {
-    /// Extract file statistics from a file descriptor. Calls `fstat` on the file to obtain
-    /// the size and allocated size.
-    fn extract_from(file: &File) -> std::io::Result<Self> {
-        let mut stat: MaybeUninit<libc::stat> = MaybeUninit::uninit();
-        // SAFETY: File descriptor valid, stat object valid.
-        let ret = unsafe { libc::fstat(file.as_raw_fd(), stat.as_mut_ptr()) };
-        if ret == -1 {
-            Err(std::io::Error::last_os_error())
-        } else {
-            // SAFETY: `stat` is initialized in the fstat non-error case.
-            let stat = unsafe { stat.assume_init_ref() };
-            let blocks = stat.st_blocks.try_into().unwrap_or(0);
-            let file_size = stat.st_size.try_into().unwrap_or(0);
-            Ok(FileStats {
-                file_size,
-                // Documented as multiples of 512
-                allocated_size: blocks * 512,
-            })
-        }
-    }
-}
-
 /// Statistics per size class and mapping.
 #[derive(Debug)]
 pub struct MapStats {
@@ -1113,43 +1044,6 @@ pub struct MapStats {
     pub active: usize,
     /// Number of dirty bytes. Consult `man 7 numa` for details.
     pub dirty: usize,
-}
-
-impl MapStats {
-    /// Extract memory map stats for `mmap` based on `numa_map`.
-    ///
-    /// The ranges of in the numa map file must be sorted by address and normalized.
-    fn extract_from(mmap: &MmapMut, numa_map: &NumaMap) -> Self {
-        // TODO: Use `addr` once our MSRV is 1.84.
-        let base = mmap.as_ptr().cast::<()>() as usize;
-        let range = match numa_map
-            .ranges
-            .binary_search_by(|range| range.address.cmp(&base))
-        {
-            Ok(pos) => Some(&numa_map.ranges[pos]),
-            // `numa_maps` only updates periodically, so we might be missing some
-            // expected ranges.
-            Err(_pos) => None,
-        };
-
-        let mut mapped = 0;
-        let mut active = 0;
-        let mut dirty = 0;
-        for property in range.iter().flat_map(|e| e.properties.iter()) {
-            match property {
-                numa_maps::Property::Dirty(d) => dirty = *d,
-                numa_maps::Property::Mapped(m) => mapped = *m,
-                numa_maps::Property::Active(a) => active = *a,
-                _ => {}
-            }
-        }
-
-        Self {
-            mapped,
-            active,
-            dirty,
-        }
-    }
 }
 
 #[cfg(test)]
@@ -1309,12 +1203,6 @@ mod test {
         for size_class in &stats.size_class {
             println!("size_class {:?}", size_class);
         }
-        for (size_class, file_stats) in &stats.file {
-            match file_stats {
-                Ok(file_stats) => println!("file_stats {size_class} {file_stats:?}"),
-                Err(e) => eprintln!("error: {e}"),
-            }
-        }
         Ok(())
     }
 
@@ -1326,7 +1214,7 @@ mod test {
             path: Some(std::env::temp_dir()),
             ..Default::default()
         });
-        let r = <Wrapper<u8>>::allocate(1000)?;
+        let r = <Wrapper<u8>>::allocate(1 << 20)?;
 
         let thread = std::thread::spawn(move || drop(r));
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -537,10 +537,47 @@ impl LocalSizeClass {
     }
 }
 
-/// Create an anonymous memory mapping with huge page hints.
+/// Create an anonymous memory mapping with huge/super page hints.
+///
+/// On Linux, applies `MADV_HUGEPAGE` for transparent huge pages.
+/// On macOS, requests 2 MiB superpages via `VM_FLAGS_SUPERPAGE_SIZE_2MB` when the
+/// allocation is a multiple of 2 MiB, falling back to regular pages on failure.
 ///
 /// Returns a tuple of `(address, mutable slice)` on success.
 fn mmap_anonymous(len: usize) -> Result<(usize, &'static mut [u8]), AllocError> {
+    // On macOS, try superpage allocation for 2 MiB-aligned sizes.
+    #[cfg(target_os = "macos")]
+    {
+        const SUPERPAGE_2MB: usize = 2 << 20;
+        if len >= SUPERPAGE_2MB && len % SUPERPAGE_2MB == 0 {
+            // VM_FLAGS_SUPERPAGE_SIZE_2MB = 0x40000, passed via the fd parameter.
+            const VM_FLAGS_SUPERPAGE_SIZE_2MB: libc::c_int = 0x40000;
+            // SAFETY: Creating an anonymous private mapping with superpage hint.
+            let ptr = unsafe {
+                libc::mmap(
+                    std::ptr::null_mut(),
+                    len,
+                    libc::PROT_READ | libc::PROT_WRITE,
+                    libc::MAP_PRIVATE | libc::MAP_ANONYMOUS,
+                    VM_FLAGS_SUPERPAGE_SIZE_2MB,
+                    0,
+                )
+            };
+            if ptr != libc::MAP_FAILED {
+                // SAFETY: `ptr` is a valid mapping of `len` bytes.
+                let slice = unsafe { std::slice::from_raw_parts_mut(ptr.cast::<u8>(), len) };
+                return Ok((ptr as usize, slice));
+            }
+            // Superpage allocation failed — fall through to regular mapping.
+            if !MADV_HUGEPAGE_WARNED.swap(true, Ordering::Relaxed) {
+                eprintln!(
+                    "lgalloc: superpage allocation failed: {}. Falling back to regular pages.",
+                    std::io::Error::last_os_error()
+                );
+            }
+        }
+    }
+
     // SAFETY: Creating an anonymous private mapping with no file descriptor.
     let ptr = unsafe {
         libc::mmap(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -537,47 +537,10 @@ impl LocalSizeClass {
     }
 }
 
-/// Create an anonymous memory mapping with huge/super page hints.
-///
-/// On Linux, applies `MADV_HUGEPAGE` for transparent huge pages.
-/// On macOS, requests 2 MiB superpages via `VM_FLAGS_SUPERPAGE_SIZE_2MB` when the
-/// allocation is a multiple of 2 MiB, falling back to regular pages on failure.
+/// Create an anonymous memory mapping with huge page hints.
 ///
 /// Returns a tuple of `(address, mutable slice)` on success.
 fn mmap_anonymous(len: usize) -> Result<(usize, &'static mut [u8]), AllocError> {
-    // On macOS, try superpage allocation for 2 MiB-aligned sizes.
-    #[cfg(target_os = "macos")]
-    {
-        const SUPERPAGE_2MB: usize = 2 << 20;
-        if len >= SUPERPAGE_2MB && len % SUPERPAGE_2MB == 0 {
-            // VM_FLAGS_SUPERPAGE_SIZE_2MB = 0x40000, passed via the fd parameter.
-            const VM_FLAGS_SUPERPAGE_SIZE_2MB: libc::c_int = 0x40000;
-            // SAFETY: Creating an anonymous private mapping with superpage hint.
-            let ptr = unsafe {
-                libc::mmap(
-                    std::ptr::null_mut(),
-                    len,
-                    libc::PROT_READ | libc::PROT_WRITE,
-                    libc::MAP_PRIVATE | libc::MAP_ANONYMOUS,
-                    VM_FLAGS_SUPERPAGE_SIZE_2MB,
-                    0,
-                )
-            };
-            if ptr != libc::MAP_FAILED {
-                // SAFETY: `ptr` is a valid mapping of `len` bytes.
-                let slice = unsafe { std::slice::from_raw_parts_mut(ptr.cast::<u8>(), len) };
-                return Ok((ptr as usize, slice));
-            }
-            // Superpage allocation failed — fall through to regular mapping.
-            if !MADV_HUGEPAGE_WARNED.swap(true, Ordering::Relaxed) {
-                eprintln!(
-                    "lgalloc: superpage allocation failed: {}. Falling back to regular pages.",
-                    std::io::Error::last_os_error()
-                );
-            }
-        }
-    }
-
     // SAFETY: Creating an anonymous private mapping with no file descriptor.
     let ptr = unsafe {
         libc::mmap(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,7 +120,7 @@ impl Handle {
 const INITIAL_SIZE: usize = 32 << 20;
 
 /// Range of valid size classes.
-pub const VALID_SIZE_CLASS: Range<usize> = 10..37;
+pub const VALID_SIZE_CLASS: Range<usize> = 20..37;
 
 /// Strategy to indicate that the OS can reclaim pages
 // TODO: On Linux, we want to use MADV_REMOVE, but that's only supported
@@ -252,7 +252,7 @@ struct SizeClassState {
     /// Handle to memory-mapped regions.
     ///
     /// We must never dereference the memory-mapped regions stored here.
-    areas: RwLock<Vec<ManuallyDrop<(File, MmapMut)>>>,
+    areas: RwLock<Vec<ManuallyDrop<(usize, usize)>>>,
     /// Injector to distribute memory globally.
     injector: Injector<Handle>,
     /// Injector to distribute memory globally, freed memory.
@@ -487,7 +487,7 @@ impl LocalSizeClass {
         let initial_capacity = std::cmp::max(1, INITIAL_SIZE / self.size_class.byte_size());
 
         let last_capacity =
-            stash.iter().last().map_or(0, |mmap| mmap.1.len()) / self.size_class.byte_size();
+            stash.iter().last().map_or(0, |mmap| mmap.1) / self.size_class.byte_size();
         let growth_dampener = LGALLOC_FILE_GROWTH_DAMPENER.load(Ordering::Relaxed);
         // We would like to grow the file capacity by a factor of `1+1/(growth_dampener+1)`,
         // but at least by `initial_capacity`.
@@ -498,7 +498,21 @@ impl LocalSizeClass {
             );
 
         let next_byte_len = next_capacity * self.size_class.byte_size();
-        let (file, mut mmap) = Self::init_file(next_byte_len)?;
+        // let (file, mut mmap) = Self::init_file(next_byte_len)?;
+
+        let mmap = unsafe {
+            libc::mmap(std::ptr::null_mut(), next_byte_len,
+                libc::PROT_READ | libc::PROT_WRITE,
+                libc::MAP_ANONYMOUS | libc::MAP_HUGETLB,
+                0,
+                0)
+        };
+        if mmap == libc::MAP_FAILED {
+            return Err(std::io::Error::last_os_error().into());
+        }
+        let slice = unsafe {
+            std::slice::from_raw_parts_mut(mmap.cast::<u8>(), next_byte_len)
+        };
 
         self.size_class_state
             .total_bytes
@@ -508,8 +522,7 @@ impl LocalSizeClass {
             .fetch_add(1, Ordering::Relaxed);
 
         // SAFETY: Memory region initialized, so pointers to it are valid.
-        let mut chunks = mmap
-            .as_mut()
+        let mut chunks = slice
             .chunks_exact_mut(self.size_class.byte_size())
             .map(|chunk| NonNull::new(chunk.as_mut_ptr()).expect("non-null"));
 
@@ -524,7 +537,7 @@ impl LocalSizeClass {
                 .push(Handle::new(ptr, self.size_class.byte_size()));
         }
 
-        stash.push(ManuallyDrop::new((file, mmap)));
+        stash.push(ManuallyDrop::new((mmap.addr(), next_byte_len)));
         Ok(mem)
     }
 

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -80,7 +80,7 @@ fn cross_thread_dealloc() -> Result<(), AllocError> {
         enabled: Some(true),
         ..Default::default()
     });
-    let r = <Wrapper<u8>>::allocate(1 << 20)?;
+    let r = <Wrapper<u8>>::allocate(2 << 20)?;
 
     let thread = std::thread::spawn(move || drop(r));
 
@@ -112,7 +112,7 @@ fn zero_capacity_nonzst() -> Result<(), AllocError> {
 #[test]
 fn stats() -> Result<(), AllocError> {
     initialize();
-    let (_ptr, _cap, handle) = allocate::<usize>(1 << 17)?;
+    let (_ptr, _cap, handle) = allocate::<usize>(1 << 18)?;
     deallocate(handle);
 
     let stats = lgalloc_stats();
@@ -128,20 +128,26 @@ fn prefetch() -> Result<(), AllocError> {
     let (ptr, cap, handle) = allocate::<u8>(2 << 20)?;
 
     // Prefetch the whole region.
-    handle.prefetch(0, cap)?;
+    handle.prefetch::<u8>(0..cap).unwrap();
 
     // Prefetch a sub-range (first 64 KiB).
-    handle.prefetch(0, 64 * 1024)?;
+    handle.prefetch::<u8>(0..64 * 1024).unwrap();
 
     // Prefetch an interior offset.
-    handle.prefetch(4096, 4096)?;
+    handle.prefetch::<u8>(4096..8192).unwrap();
 
-    // Zero-length is a no-op.
-    handle.prefetch(0, 0)?;
+    // Empty range is a no-op.
+    handle.prefetch::<u8>(0..0).unwrap();
 
     // Out of bounds returns an error.
-    assert!(handle.prefetch(0, cap + 1).is_err());
-    assert!(handle.prefetch(cap, 1).is_err());
+    assert!(handle.prefetch::<u8>(0..cap + 1).is_err());
+    assert!(handle.prefetch::<u8>(cap..cap + 1).is_err());
+
+    // Typed prefetch: element indices.
+    let elem_cap = cap / std::mem::size_of::<u64>();
+    handle.prefetch::<u64>(0..elem_cap).unwrap();
+    handle.prefetch::<u64>(100..200).unwrap();
+    assert!(handle.prefetch::<u64>(0..elem_cap + 1).is_err());
 
     // Verify the memory is accessible.
     let slice = unsafe { std::slice::from_raw_parts_mut(ptr.as_ptr(), cap) };

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -1,0 +1,123 @@
+use std::mem::{ManuallyDrop, MaybeUninit};
+use std::ptr::NonNull;
+use std::time::Duration;
+
+use lgalloc::{
+    allocate, deallocate, lgalloc_set_config, lgalloc_stats, AllocError, BackgroundWorkerConfig,
+    Handle, LgAlloc,
+};
+
+fn initialize() {
+    lgalloc_set_config(
+        LgAlloc::new()
+            .enable()
+            .with_background_config(BackgroundWorkerConfig {
+                interval: Duration::from_secs(1),
+                clear_bytes: 4 << 20,
+            })
+            .growth_dampener(1),
+    );
+}
+
+struct Wrapper<T> {
+    handle: MaybeUninit<Handle>,
+    ptr: NonNull<MaybeUninit<T>>,
+    cap: usize,
+}
+
+unsafe impl<T: Send> Send for Wrapper<T> {}
+unsafe impl<T: Sync> Sync for Wrapper<T> {}
+
+impl<T> Wrapper<T> {
+    fn allocate(capacity: usize) -> Result<Self, AllocError> {
+        let (ptr, cap, handle) = allocate(capacity)?;
+        assert!(cap > 0);
+        let handle = MaybeUninit::new(handle);
+        Ok(Self { ptr, cap, handle })
+    }
+
+    fn as_slice(&mut self) -> &mut [MaybeUninit<T>] {
+        unsafe { std::slice::from_raw_parts_mut(self.ptr.as_ptr(), self.cap) }
+    }
+}
+
+impl<T> Drop for Wrapper<T> {
+    fn drop(&mut self) {
+        unsafe { deallocate(self.handle.assume_init_read()) };
+    }
+}
+
+#[test]
+fn test_readme() -> Result<(), AllocError> {
+    initialize();
+
+    // Allocate memory
+    let (ptr, cap, handle) = allocate::<u8>(2 << 20)?;
+    // SAFETY: `allocate` returns a valid memory region and errors otherwise.
+    let mut vec = ManuallyDrop::new(unsafe { Vec::from_raw_parts(ptr.as_ptr(), 0, cap) });
+
+    // Write into region, make sure not to reallocate vector.
+    vec.extend_from_slice(&[1, 2, 3, 4]);
+
+    // We can read from the vector.
+    assert_eq!(&*vec, &[1, 2, 3, 4]);
+
+    // Deallocate after use
+    deallocate(handle);
+    Ok(())
+}
+
+#[test]
+fn allocate_and_write() -> Result<(), AllocError> {
+    initialize();
+    <Wrapper<u8>>::allocate(4 << 20)?.as_slice()[0] = MaybeUninit::new(1);
+    Ok(())
+}
+
+#[test]
+fn cross_thread_dealloc() -> Result<(), AllocError> {
+    lgalloc_set_config(&LgAlloc {
+        enabled: Some(true),
+        ..Default::default()
+    });
+    let r = <Wrapper<u8>>::allocate(1 << 20)?;
+
+    let thread = std::thread::spawn(move || drop(r));
+
+    thread.join().unwrap();
+    Ok(())
+}
+
+#[test]
+fn zst() -> Result<(), AllocError> {
+    initialize();
+    <Wrapper<()>>::allocate(10)?;
+    Ok(())
+}
+
+#[test]
+fn zero_capacity_zst() -> Result<(), AllocError> {
+    initialize();
+    <Wrapper<()>>::allocate(0)?;
+    Ok(())
+}
+
+#[test]
+fn zero_capacity_nonzst() -> Result<(), AllocError> {
+    initialize();
+    <Wrapper<()>>::allocate(0)?;
+    Ok(())
+}
+
+#[test]
+fn stats() -> Result<(), AllocError> {
+    initialize();
+    let (_ptr, _cap, handle) = allocate::<usize>(1 << 17)?;
+    deallocate(handle);
+
+    let stats = lgalloc_stats();
+
+    assert!(!stats.size_class.is_empty());
+
+    Ok(())
+}

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -121,3 +121,33 @@ fn stats() -> Result<(), AllocError> {
 
     Ok(())
 }
+
+#[test]
+fn prefetch() -> Result<(), AllocError> {
+    initialize();
+    let (ptr, cap, handle) = allocate::<u8>(2 << 20)?;
+
+    // Prefetch the whole region.
+    handle.prefetch(0, cap)?;
+
+    // Prefetch a sub-range (first 64 KiB).
+    handle.prefetch(0, 64 * 1024)?;
+
+    // Prefetch an interior offset.
+    handle.prefetch(4096, 4096)?;
+
+    // Zero-length is a no-op.
+    handle.prefetch(0, 0)?;
+
+    // Out of bounds returns an error.
+    assert!(handle.prefetch(0, cap + 1).is_err());
+    assert!(handle.prefetch(cap, 1).is_err());
+
+    // Verify the memory is accessible.
+    let slice = unsafe { std::slice::from_raw_parts_mut(ptr.as_ptr(), cap) };
+    slice[0] = 42;
+    assert_eq!(slice[0], 42);
+
+    deallocate(handle);
+    Ok(())
+}

--- a/tests/concurrent.rs
+++ b/tests/concurrent.rs
@@ -1,0 +1,125 @@
+use std::mem::MaybeUninit;
+use std::ptr::NonNull;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use lgalloc::{
+    allocate, deallocate, lgalloc_set_config, lgalloc_stats, AllocError, BackgroundWorkerConfig,
+    Handle, LgAlloc,
+};
+
+fn initialize() {
+    lgalloc_set_config(
+        LgAlloc::new()
+            .enable()
+            .with_background_config(BackgroundWorkerConfig {
+                interval: Duration::from_secs(1),
+                clear_bytes: 4 << 20,
+            })
+            .growth_dampener(1),
+    );
+}
+
+struct Wrapper<T> {
+    handle: MaybeUninit<Handle>,
+    ptr: NonNull<MaybeUninit<T>>,
+    cap: usize,
+}
+
+unsafe impl<T: Send> Send for Wrapper<T> {}
+unsafe impl<T: Sync> Sync for Wrapper<T> {}
+
+impl<T> Wrapper<T> {
+    fn allocate(capacity: usize) -> Result<Self, AllocError> {
+        let (ptr, cap, handle) = allocate(capacity)?;
+        assert!(cap > 0);
+        let handle = MaybeUninit::new(handle);
+        Ok(Self { ptr, cap, handle })
+    }
+
+    fn as_slice(&mut self) -> &mut [MaybeUninit<T>] {
+        unsafe { std::slice::from_raw_parts_mut(self.ptr.as_ptr(), self.cap) }
+    }
+}
+
+impl<T> Drop for Wrapper<T> {
+    fn drop(&mut self) {
+        unsafe { deallocate(self.handle.assume_init_read()) };
+    }
+}
+
+#[test]
+fn concurrent_single_alloc() -> Result<(), AllocError> {
+    initialize();
+    let until = Arc::new(AtomicBool::new(true));
+
+    let inner = || {
+        let until = Arc::clone(&until);
+        move || {
+            let mut i = 0;
+            let until = &*until;
+            while until.load(Ordering::Relaxed) {
+                i += 1;
+                let mut r = <Wrapper<u8>>::allocate(4 << 20).unwrap();
+                r.as_slice()[0] = MaybeUninit::new(1);
+            }
+            println!("repetitions: {i}");
+        }
+    };
+    let handles = [
+        std::thread::spawn(inner()),
+        std::thread::spawn(inner()),
+        std::thread::spawn(inner()),
+        std::thread::spawn(inner()),
+    ];
+    std::thread::sleep(Duration::from_secs(4));
+    until.store(false, Ordering::Relaxed);
+    for handle in handles {
+        handle.join().unwrap();
+    }
+    Ok(())
+}
+
+#[test]
+fn concurrent_batch_alloc() -> Result<(), AllocError> {
+    initialize();
+    let until = Arc::new(AtomicBool::new(true));
+
+    let inner = || {
+        let until = Arc::clone(&until);
+        move || {
+            let mut i = 0;
+            let until = &*until;
+            let batch = 64;
+            let mut buffer = Vec::with_capacity(batch);
+            while until.load(Ordering::Relaxed) {
+                i += 64;
+                buffer.extend((0..batch).map(|_| {
+                    let mut r = <Wrapper<u8>>::allocate(2 << 20).unwrap();
+                    r.as_slice()[0] = MaybeUninit::new(1);
+                    r
+                }));
+                buffer.clear();
+            }
+            println!("repetitions vec: {i}");
+        }
+    };
+    let handles = [
+        std::thread::spawn(inner()),
+        std::thread::spawn(inner()),
+        std::thread::spawn(inner()),
+        std::thread::spawn(inner()),
+    ];
+    std::thread::sleep(Duration::from_secs(4));
+    until.store(false, Ordering::Relaxed);
+    for handle in handles {
+        handle.join().unwrap();
+    }
+    std::thread::sleep(Duration::from_secs(1));
+    let stats = lgalloc_stats();
+    for size_class in &stats.size_class {
+        println!("size_class {:?}", size_class);
+    }
+    Ok(())
+}

--- a/tests/disable.rs
+++ b/tests/disable.rs
@@ -1,0 +1,7 @@
+use lgalloc::{allocate, lgalloc_set_config, AllocError, LgAlloc};
+
+#[test]
+fn disabled_allocator_returns_error() {
+    lgalloc_set_config(&*LgAlloc::new().disable());
+    assert!(matches!(allocate::<u8>(1 << 20), Err(AllocError::Disabled)));
+}

--- a/tests/disable.rs
+++ b/tests/disable.rs
@@ -3,5 +3,5 @@ use lgalloc::{allocate, lgalloc_set_config, AllocError, LgAlloc};
 #[test]
 fn disabled_allocator_returns_error() {
     lgalloc_set_config(&*LgAlloc::new().disable());
-    assert!(matches!(allocate::<u8>(1 << 20), Err(AllocError::Disabled)));
+    assert!(matches!(allocate::<u8>(2 << 20), Err(AllocError::Disabled)));
 }


### PR DESCRIPTION
Replace file-backed memory mappings with `MAP_ANONYMOUS` + `MADV_HUGEPAGE`.
Swap-enabled hosts make file-backed mappings counterproductive: they cause writeback I/O, reserve disk space, and cannot use transparent huge pages.
Anonymous mappings with THP hints give 2 MiB pages, reducing TLB misses and avoiding all file I/O.

Breaking changes:
* Remove `path` config, `with_path()`, `FileStats`, `MapStats`, `lgalloc_stats_with_mapping()`
* Rename `file_growth_dampener` → `growth_dampener`
* Raise minimum size class from 1 MiB to 2 MiB (one huge page)
* `Handle::prefetch` now takes `prefetch::<T>(Range<usize>)` with a separate `PrefetchError`
* Remove `numa_maps`, `memmap2`, `tempfile` dependencies

Other changes:
* Fix madvise strategy: `MADV_FREE` for background clear, `MADV_DONTNEED` for eager return (was `MADV_REMOVE` which fails on anonymous memory)
* Handle `MADV_HUGEPAGE` failure gracefully (warn once, not error)
* Add `munmap` in `GlobalStealer::drop`
* Add `Handle::prefetch` for `MADV_WILLNEED` hints
* Move tests to integration test files, drop `serial_test`
* Add allocation benchmarks comparing lgalloc, system allocator, and raw mmap